### PR TITLE
feat(svcmgr): add noop service manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ This contains all of the currently available parameters:
 * `dir`: this specifies the directory containing the certificate specs
 * `svcmgr`: this specifies the service manager to use for restarting
   or reloading services. This can be `systemd` (using `systemctl`),
-  `sysv` (using `service`), or `circus` (using `circusctl`).
+  `sysv` (using `service`), `circus` (using `circusctl`), or `dummy`
+  (no restart/reload behavior).
 * `before`: this is the interval before a certificate expires to start
   attempting to renew it.
 * `interval`: this controls how often to check certificate expirations

--- a/cli/root.go
+++ b/cli/root.go
@@ -70,7 +70,7 @@ func init() {
 
 	RootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "f", "", "config file (default is /etc/certmgr/certmgr.yaml)")
 	RootCmd.PersistentFlags().StringVarP(&manager.Dir, "dir", "d", "", "directory containing certificate specs")
-	RootCmd.PersistentFlags().StringVarP(&manager.ServiceManager, "svcmgr", "m", "", "service manager (one of systemd, sysv, or circus)")
+	RootCmd.PersistentFlags().StringVarP(&manager.ServiceManager, "svcmgr", "m", "", "service manager (one of systemd, sysv, circus, or dummy)")
 	RootCmd.PersistentFlags().StringVarP(&manager.Before, "before", "t", "", "how long before certificates expire to start renewing (in the form Nh)")
 	RootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "enable debug mode")
 	RootCmd.Flags().BoolVarP(&sync, "sync", "s", false, "the first certificate check should be synchronous")

--- a/svcmgr/dummy.go
+++ b/svcmgr/dummy.go
@@ -1,0 +1,18 @@
+package svcmgr
+
+/////////////////////
+// No integration! //
+/////////////////////
+type dummy struct{}
+
+func (dummy) RestartService(string) error {
+	return nil
+}
+
+func (dummy) ReloadService(string) error {
+	return nil
+}
+
+func init() {
+	supported["dummy"] = dummy{}
+}

--- a/svcmgr/svcmgr.go
+++ b/svcmgr/svcmgr.go
@@ -1,7 +1,8 @@
 // Package svcmgr contains integration for managing services on a
 // machine.
 //
-// Currently supported service managers are systemd, circus, and sysv.
+// Currently supported service managers are systemd, circus, sysv,
+// and dummy.
 package svcmgr
 
 import (


### PR DESCRIPTION
Adds a noop service manager that satisfies the svcmanager.Manager
interface, but doesn't actually do anything.

In some scenarios we want to run certmgr to handle issuing and renewing
certificates, but would rather watch for certificate and key changes
than use a supervisor.