### PR TITLE
Remove certificates older than their cert spec.

### DIFF
--- a/cli/version.go
+++ b/cli/version.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-var currentVersion = "1.0.0"
+var currentVersion = "1.1.0"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",

--- a/mgr/manager.go
+++ b/mgr/manager.go
@@ -176,6 +176,7 @@ func (m *Manager) Load() error {
 			}
 		}
 
+		log.Infof("spec CA: %#v\n", cert.CA)
 		m.Certs = append(m.Certs, cert)
 		metrics.WatchCount.Inc()
 		return nil


### PR DESCRIPTION
This is the easiest way to force a regeneration of the certificate
when the spec changes.

This addresses #9.