### PR TITLE
Add "ensure" command.

### DIFF
--- a/cli/ensure.go
+++ b/cli/ensure.go
@@ -1,0 +1,45 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var ensureTolerance = 3
+
+var ensureCmd = &cobra.Command{
+	Use:   "ensure",
+	Short: "Ensure all certificate specs have matching keypairs.",
+	Long: `Certificate manager will load all certificate specs, and ensure that the
+TLS key pairs they identify exist, are valid, and that they are up-to-date.`,
+	Run: Ensure,
+}
+
+func Ensure(cmd *cobra.Command, args []string) {
+	mgr, err := newManager()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed: %s\n", err)
+		os.Exit(1)
+	}
+
+	err = mgr.Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed: %s\n", err)
+		os.Exit(1)
+	}
+
+	err = mgr.MustCheckCerts(ensureTolerance)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed: %s\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("OK")
+}
+
+func init() {
+	RootCmd.AddCommand(ensureCmd)
+	ensureCmd.Flags().IntVarP(&ensureTolerance, "tries", "n", ensureTolerance, "number of times to retry refreshing a certificate")
+}

--- a/cli/version.go
+++ b/cli/version.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-var currentVersion = "1.1.2"
+var currentVersion = "1.2.0"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",

--- a/vendor/github.com/cloudflare/cfssl/csr/csr.go
+++ b/vendor/github.com/cloudflare/cfssl/csr/csr.go
@@ -402,7 +402,7 @@ func Generate(priv crypto.Signer, req *CertificateRequest) (csr []byte, err erro
 		Bytes: csr,
 	}
 
-	log.Info("encoded CSR")
+	log.Debug("encoded CSR")
 	csr = pem.EncodeToMemory(&block)
 	return
 }


### PR DESCRIPTION
This ensures all certificate specs have valid key pairs, exiting
with a failure if it can't.