### PR TITLE
cert: add support for writing CA certificates to disk.

### DIFF
--- a/cert/file.go
+++ b/cert/file.go
@@ -23,12 +23,13 @@ type File struct {
 	mode     os.FileMode
 }
 
-// parse sets up the File structure from its string parameters; the
+// Parse sets up the File structure from its string parameters; the
 // hint is used to provide a hint as to what file is being processed
 // for use in error messages. This includes validating that the user
 // and group referenced exist; providing sensible defaults, and
-// processing the mode.
-func (f *File) parse(hint string) (err error) {
+// processing the mode. The method is intended to allow set up after
+// unmarshalling from a configuration file.
+func (f *File) Parse(hint string) (err error) {
 	if f.Path == "" {
 		return fmt.Errorf("cert: missing path for %s", hint)
 	}

--- a/cli/version.go
+++ b/cli/version.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-var currentVersion = "1.3.1"
+var currentVersion = "1.4.0"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",


### PR DESCRIPTION
An oft-requested feature is to allow certmgr to write the CA certificate
to disk. This change provides support for that. If no file section is
provided in the CA configuration (as is the case in all current
configurations), certmgr's behaviour is unmodified with the exception of
a log message noting that the certificate will not be written.