### PR TITLE
Fix logic when writing CA certificate.

### DIFF
--- a/cert/cert.go
+++ b/cert/cert.go
@@ -80,9 +80,15 @@ func (ca *CA) Load() error {
 			log.Infof("cert: existing CA certificate at %s is current, won't overwrite",
 				ca.File.Path)
 		}
+	} else if os.IsNotExist(err) {
+		err = ioutil.WriteFile(ca.File.Path, []byte(resp.Certificate), 0644)
+		if err != nil {
+			return err
+		}
+		log.Infof("cert: wrote CA certificate: %s", ca.File.Path)
 	}
 
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil {
 		return err
 	}
 

--- a/cli/version.go
+++ b/cli/version.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-var currentVersion = "1.4.0"
+var currentVersion = "1.4.1"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",

--- a/mgr/manager.go
+++ b/mgr/manager.go
@@ -392,7 +392,7 @@ func (m *Manager) renewCert(cert *cert.Spec) error {
 		}
 
 		cert.ResetBackoff()
-		return nil
+		return cert.CA.Load()
 	}
 	stop := time.Now()
 


### PR DESCRIPTION
Previously, if the CA certificate didn't exist, it would throw an error,
which is the wrong behaviour.