### PR TITLE
A collection of minor improvements.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 dist: trusty
 sudo: false
 go:
-  - 1.8.x
+  - 1.9.x
 install:
   - go get github.com/Masterminds/glide
 script:
@@ -11,7 +11,7 @@ script:
 jobs:
   include:
   - stage: Cross-Build
-    go: 1.8.x
+    go: 1.9.x
     env:
       - CGO_ENABLED=0
     script:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ When run without any subcommands, certmgr will start monitoring
 certificates. The configuration and specifications can be validated
 using the `check` subcommand.
 
+**Note**: due to a [bug](https://github.com/golang/go/issues/19395) in
+the os/user package, `certmgr` requires Go 1.9 or later to use the
+user/group functionality in file specifications.
+
 ## Web server
 
 When appropriately configured, `certmgr` will start a web server that
@@ -137,7 +141,12 @@ An example certificate spec:
         "remote": "ca.example.net:8888",
         "auth_key": "012345678012345678",
         "label": "www_ca",
-        "profile": "three-month"
+        "profile": "three-month",
+        "file": {
+            "path": "/etc/myservice/ca.pem",
+            "owner": "www-data",
+            "group": "www-data"
+        }
     }
 }
 ```
@@ -183,6 +192,8 @@ The CA specification contains the following fields:
 * `auth_key`: the authentication key used to request a certificate.
 * `label`: the CA to use for the certificate.
 * `profile`: the CA profile that should be used.
+* `file`: if this is included, the CA certificate will be saved here. It
+  follows the same file specification format above.
 
 ## Subcommands
 

--- a/cert/cert.go
+++ b/cert/cert.go
@@ -42,7 +42,9 @@ type CA struct {
 // CA certificate to disk.
 func (ca *CA) Load() error {
 	if ca.File == nil {
-		log.Info("cert: no CA file provided, won't write to disk")
+		// NB: this used to be an info message, but it caused
+		// more confusion than anything else.
+		log.Debug("cert: no CA file provided, won't write the CA file to disk")
 		return nil
 	}
 

--- a/cli/version.go
+++ b/cli/version.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-var currentVersion = "1.4.2"
+var currentVersion = "1.4.3"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",

--- a/mgr/manager.go
+++ b/mgr/manager.go
@@ -140,6 +140,12 @@ var validActions = map[string]bool{
 	"nop":     true,
 }
 
+var validExtensions = map[string]bool{
+	".json": true,
+	".yaml": true,
+	".yml":  true,
+}
+
 // Load reads the certificate specs from the spec directory.
 func (m *Manager) Load() error {
 	if m.Certs != nil || len(m.Certs) > 0 {
@@ -158,6 +164,11 @@ func (m *Manager) Load() error {
 				return nil
 			}
 			return filepath.SkipDir
+		}
+
+		ext := filepath.Ext(path)
+		if !validExtensions[ext] {
+			return nil
 		}
 
 		log.Info("manager: loading spec from ", path)


### PR DESCRIPTION
* Only look for valid YAML/JSON files in the cert spec
  dir (e.g. fix #33).
* Update Travis to use Go 1.9 to fix a Go bug in the
  user lookups (#30).
* Update README to include CA file path writing.
* Remove the informational message about not writing a CA file
  if no file path was provided. This was useful in testing,
  but has caused a great deal of confusion among users.
* Bump the patch version to trigger a release using the new Go version.

Use Go-1.9 and add CA file writes to README.