### PR TITLE
Support OpenRC as a service manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ This contains all of the currently available parameters:
 * `dir`: this specifies the directory containing the certificate specs
 * `svcmgr`: this specifies the service manager to use for restarting
   or reloading services. This can be `systemd` (using `systemctl`),
-  `sysv` (using `service`), `circus` (using `circusctl`), or `dummy`
-  (no restart/reload behavior).
+  `sysv` (using `service`), `circus` (using `circusctl`), `openrc` (using `rc-service`)
+  or `dummy` (no restart/reload behavior).
 * `before`: this is the interval before a certificate expires to start
   attempting to renew it.
 * `interval`: this controls how often to check certificate expirations

--- a/cli/root.go
+++ b/cli/root.go
@@ -70,7 +70,7 @@ func init() {
 
 	RootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "f", "", "config file (default is /etc/certmgr/certmgr.yaml)")
 	RootCmd.PersistentFlags().StringVarP(&manager.Dir, "dir", "d", "", "directory containing certificate specs")
-	RootCmd.PersistentFlags().StringVarP(&manager.ServiceManager, "svcmgr", "m", "", "service manager (one of systemd, sysv, circus, or dummy)")
+	RootCmd.PersistentFlags().StringVarP(&manager.ServiceManager, "svcmgr", "m", "", "service manager (one of systemd, sysv, circus, openrc, or dummy)")
 	RootCmd.PersistentFlags().StringVarP(&manager.Before, "before", "t", "", "how long before certificates expire to start renewing (in the form Nh)")
 	RootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "enable debug mode")
 	RootCmd.Flags().BoolVarP(&sync, "sync", "s", false, "the first certificate check should be synchronous")

--- a/svcmgr/openrc.go
+++ b/svcmgr/openrc.go
@@ -1,0 +1,22 @@
+package svcmgr
+
+import "github.com/cloudflare/cfssl/log"
+
+///////////////////
+// OpenRC support. //
+///////////////////
+type openrc struct{}
+
+func (sm openrc) RestartService(service string) error {
+	log.Info("restarting service ", service)
+	return run("rc-service", service, "restart")
+}
+
+func (sm openrc) ReloadService(service string) error {
+	log.Info("reloading service ", service)
+	return run("rc-service", service, "reload")
+}
+
+func init() {
+	supported["openrc"] = openrc{}
+}

--- a/svcmgr/svcmgr.go
+++ b/svcmgr/svcmgr.go
@@ -2,7 +2,7 @@
 // machine.
 //
 // Currently supported service managers are systemd, circus, sysv,
-// and dummy.
+// openrc, and dummy.
 package svcmgr
 
 import (


### PR DESCRIPTION
This PR adds support for https://github.com/OpenRC/openrc as a service manager.