### PR TITLE
Allow storing auth_key in a file via auth_key_file configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ The CA specification contains the following fields:
 * `remote`: the CA to use. If not provided, the default remote from
   the config file is used.
 * `auth_key`: the authentication key used to request a certificate.
+* `auth_key_file`: optional, if defined read the auth_key from this. If
+  `auth_key` and `auth_key_file` is defined, `auth_key` is used.
 * `label`: the CA to use for the certificate.
 * `profile`: the CA profile that should be used.
 * `file`: if this is included, the CA certificate will be saved here. It


### PR DESCRIPTION
If you're managing certmgr definitions via a SCM, you *want* to see the diff
for how one of these files changed; however, you don't want to expose the auth
key via that diff.

Thus add an option to allow reading the auth_key from a file.  That file you
tell your SCM to not show changes in, but for certmgr definitions that consume
it, using auth_key_file allows you to again show those diffs.