### PR TITLE
Add documentation for certmgr -d usage against a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,12 +228,16 @@ In addition to the certificate manager, there are a few utility
 functions specified:
 
 * `check`: validates the configuration file and all the certificate
-  specs available in the certificate spec directory.
+  specs available in the certificate spec directory.  Note that if you
+  wish to operate on just one spec, you can use `-d /path/to/that/spec`
+  to accomplish it.
 * `clean`: removes all of the certificates and private keys specified
-  by the certificate specs.
+  by the certificate specs.  Note that if you wish to operate on just one spec,
+  you can use `-d /path/to/that/spec` to accomplish it.
 * `ensure`: attempts to load all certificate specs, and ensure that
   the TLS key pairs they identify exist, are valid, and that they are
-  up-to-date.
+  up-to-date.  Note that if you wish to operate on just one spec, you
+  can use `-d /path/to/that/spec` to accomplish this.
 * `genconfig`: generates a default configuration file and ensures the
   default service directory exists.
 * `version`: prints certificate manager's version, the version of Go

--- a/cli/root.go
+++ b/cli/root.go
@@ -79,7 +79,7 @@ func init() {
 	cobra.OnInitialize(initConfig)
 
 	RootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "f", "", "config file (default is /etc/certmgr/certmgr.yaml)")
-	RootCmd.PersistentFlags().StringVarP(&manager.Dir, "dir", "d", "", "directory containing certificate specs")
+	RootCmd.PersistentFlags().StringVarP(&manager.Dir, "dir", "d", "", "either the directory containing certificate specs, or the path to the spec file you wish to operate on")
 	backends := []string{}
 	for backend := range svcmgr.SupportedBackends {
 		backends = append(backends, backend)


### PR DESCRIPTION
It's not well known (see #22), but you can either pass a directory or file
via certmgr {ensure,check,clean} -d /path/to/that/file .  This allows enforcing
just the spec you care about.

Thus update the help to clarify that you can pass a file if desired.