### PR TITLE
Let it be possible to specify optional CAcert for trust of remote cfssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ An example certificate spec:
             "path": "/etc/myservice/ca.pem",
             "owner": "www-data",
             "group": "www-data"
-        }
+        },
+        root_ca: "/etc/cfssl/api_server_ca.pem"
     }
 }
 ```
@@ -202,6 +203,10 @@ The CA specification contains the following fields:
 * `profile`: the CA profile that should be used.
 * `file`: if this is included, the CA certificate will be saved here. It
   follows the same file specification format above.
+* `root_ca`: optionally, a path to a certificate to trust as CA for the
+  cfssl API server certificate. Usable if the "remote" is tls enabled
+  and configured with a self-signed certificate. By default,
+  the system root CA chain is trusted.
 
 ## `command svcmgr` and how to use it
 

--- a/cert/cert.go
+++ b/cert/cert.go
@@ -43,7 +43,7 @@ type CA struct {
 
 func (ca *CA) getRemoteCert() ([]byte, error) {
 	var tlsConfig tls.Config
-	if len(ca.RootCACert) > 0 {
+	if ca.RootCACert != "" {
 		rootCABytes, err := ioutil.ReadFile(ca.RootCACert)
 		if err != nil {
 			return nil, err

--- a/cert/cert.go
+++ b/cert/cert.go
@@ -42,7 +42,7 @@ type CA struct {
 }
 
 func (ca *CA) getRemoteCert() ([]byte, error) {
-	var tlsConfig tls.Config
+	var tlsConfig *tls.Config
 	if ca.RootCACert != "" {
 		rootCABytes, err := ioutil.ReadFile(ca.RootCACert)
 		if err != nil {
@@ -54,12 +54,12 @@ func (ca *CA) getRemoteCert() ([]byte, error) {
 		if !ok {
 			return nil, errors.New("failed to parse rootCA certs")
 		}
-		tlsConfig = tls.Config{
+		tlsConfig = &tls.Config{
 			RootCAs: rootCaCertPool,
 		}
 	}
 
-	remote := client.NewServerTLS(ca.Remote, &tlsConfig)
+	remote := client.NewServerTLS(ca.Remote, tlsConfig)
 	infoReq := &info.Req{
 		Label:   ca.Label,
 		Profile: ca.Profile,


### PR DESCRIPTION
If you run cfssl apiserver tls-enabled, it is currently not possible to use self-signed certificate, because certmgr will reject it.

This PR makes it possible to use self-signed certificate on the cfssl apiserver, by providing an optional cert-spec option `root_ca`.