### PR TITLE
certmgr ensure: Add optional running of configured actions.

### DIFF
--- a/cli/ensure.go
+++ b/cli/ensure.go
@@ -8,6 +8,7 @@ import (
 )
 
 var ensureTolerance = 3
+var enableActions = false
 
 var ensureCmd = &cobra.Command{
 	Use:   "ensure",
@@ -30,7 +31,7 @@ func Ensure(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	err = mgr.MustCheckCerts(ensureTolerance)
+	err = mgr.MustCheckCerts(ensureTolerance, enableActions)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed: %s\n", err)
 		os.Exit(1)
@@ -42,4 +43,5 @@ func Ensure(cmd *cobra.Command, args []string) {
 func init() {
 	RootCmd.AddCommand(ensureCmd)
 	ensureCmd.Flags().IntVarP(&ensureTolerance, "tries", "n", ensureTolerance, "number of times to retry refreshing a certificate")
+	ensureCmd.Flags().BoolVarP(&enableActions, "enableActions", "", enableActions, "if passed, run the certificates svcmgr actions; defaults to not running them")
 }

--- a/mgr/manager.go
+++ b/mgr/manager.go
@@ -325,7 +325,7 @@ func (m *Manager) CheckCertsSync() int {
 // MustCheckCerts acts like CheckCerts, except it's synchronous and
 // has a maxmimum number of failures that are tolerated. If tolerate
 // is less than 1, it will be set to 1.
-func (m *Manager) MustCheckCerts(tolerance int) error {
+func (m *Manager) MustCheckCerts(tolerance int, enableActions bool) error {
 	if tolerance < 1 {
 		tolerance = 1
 	}
@@ -378,6 +378,17 @@ func (m *Manager) MustCheckCerts(tolerance int) error {
 			continue
 		}
 		log.Infof("manager: certificate spec %s successfully processed", cert.cert.Path)
+		if enableActions {
+			log.Debug("taking action due to key refresh")
+			err := cert.cert.TakeAction("key")
+
+			// Even though there was an error managing the service
+			// associated with the certificate, the certificate has been
+			// renewed.
+			if err != nil {
+				log.Errorf("manager: %s", err)
+			}
+		}
 
 		if len(queue) == 0 {
 			log.Infof("manager: certificate queue is clear")


### PR DESCRIPTION
This preserves the original behaviour of not running actions for `certmgr ensure`,
but adds --enableActions to turn on svcmgr/actions being ran for a given spec
for a one time run.