### PR TITLE
Add debug statement for command svcmgr, add `ensure --forceRegen`, cut v1.6.3

### DIFF
--- a/cert/cert.go
+++ b/cert/cert.go
@@ -419,10 +419,15 @@ func (spec *Spec) Lifespan() time.Duration {
 	}
 	if isTooOld(spec.Key.Path) || isTooOld(spec.Cert.Path) {
 		// This is necessary to essentially force cfssl to regenerate since it's not spec aware.
-		spec.tr.Provider.Certificate().NotAfter = specStat.ModTime()
+		spec.ResetLifespan()
 		return 0
 	}
 	return spec.tr.Lifespan()
+}
+
+// Reset the lifespan to force cfssl to regenerate
+func (spec *Spec) ResetLifespan() {
+	spec.tr.Provider.Certificate().NotAfter = time.Time{}
 }
 
 // Certificate returns the x509.Certificate associated with the spec

--- a/cli/ensure.go
+++ b/cli/ensure.go
@@ -9,6 +9,7 @@ import (
 
 var ensureTolerance = 3
 var enableActions = false
+var forceRegen = false
 
 var ensureCmd = &cobra.Command{
 	Use:   "ensure",
@@ -31,7 +32,7 @@ func Ensure(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	err = mgr.MustCheckCerts(ensureTolerance, enableActions)
+	err = mgr.MustCheckCerts(ensureTolerance, enableActions, forceRegen)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed: %s\n", err)
 		os.Exit(1)
@@ -44,4 +45,5 @@ func init() {
 	RootCmd.AddCommand(ensureCmd)
 	ensureCmd.Flags().IntVarP(&ensureTolerance, "tries", "n", ensureTolerance, "number of times to retry refreshing a certificate")
 	ensureCmd.Flags().BoolVarP(&enableActions, "enableActions", "", enableActions, "if passed, run the certificates svcmgr actions; defaults to not running them")
+	ensureCmd.Flags().BoolVarP(&forceRegen, "forceRegen", "", forceRegen, "if passed, ignore TTL checks and force regeneration of all specs")
 }

--- a/cli/version.go
+++ b/cli/version.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-var currentVersion = "1.6.2"
+var currentVersion = "1.6.3"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",

--- a/svcmgr/command.go
+++ b/svcmgr/command.go
@@ -32,6 +32,7 @@ func newCommandManager(action string, service string) (Manager, error) {
 		log.Warningf("svcmgr 'command': service '%s' for action '%s' doesn't do anything, ignoring", service, action)
 	}
 	if canCheckSyntax {
+		log.Debugf("svcmgr 'command': validating the action definition %s", action)
 		err := run(shellBinary, "-n", "-c", action)
 		if err != nil {
 			return nil, fmt.Errorf("svcmgr 'command': action '%s' failed bash -n -c parse checks: %s", action, err)


### PR DESCRIPTION
This allows you to pre-emptively force a regen, without having to wipe the materials from disk first.  This is useful for certain operational steps.  It shouldn't default on, but it should be possible to override the internal calculation without removing PKI material from disk to force the run.
    
From a development and debugging standpoint, this is also useful for when you're iterating on a spec's definition (action in particular) and need to force certmgr to run so you can validate it.
    
Again, one can accomplish the same via wiping the cert/key from disk, but that's a crappy workflow and it has some operational risks that may not be desirable- for example, if the process has an inotify in place for tracking the key/cert.

Aside from that, there is also a tweak to the command svcmgr's debugging to make it clearer why a `bash -n` invocation is being ran.