### PR TITLE
Fix regression introduced in 1.6.1 inducing actions being continually ran upon remote CA change

### DIFF
--- a/cert/cert.go
+++ b/cert/cert.go
@@ -80,8 +80,6 @@ func (ca *CA) writeCert(cert []byte) error {
 	}
 	log.Infof("cert: wrote CA certificate: %s", ca.File.Path)
 
-	// see CA.Load(); strip prefix/trailing whitespace to ensure our bytes.Equal() checks don't false positive.
-	ca.pem = []byte(strings.TrimSpace(string(cert[:])))
 	err = ca.File.Set()
 	return err
 }
@@ -131,6 +129,11 @@ func (ca *CA) Refresh() (bool, error) {
 
 	if ca.File != nil {
 		err = ca.writeCert(cert)
+	}
+	// If there were no errors, update our internal notion of what the CA is.
+	if err != nil {
+		// see CA.Load(); strip prefix/trailing whitespace to ensure our bytes.Equal() checks don't false positive.
+		ca.pem = []byte(strings.TrimSpace(string(cert[:])))
 	}
 
 	return true, err

--- a/mgr/manager.go
+++ b/mgr/manager.go
@@ -29,6 +29,7 @@ type CertServiceManager struct {
 }
 
 func (csm *CertServiceManager) TakeAction(change_type string) error {
+	log.Infof("manager: executing configured action due to change type %s for %s", change_type, csm.Cert.Path)
 	ca_path := ""
 	if csm.CA.File != nil {
 		ca_path = csm.CA.File.Path


### PR DESCRIPTION
In 1f1c919, multiple CA bugs were fixed- mostly issues where
certmgr was triggering an action for a spec because it thought the CA had changed
(but it had not).

That commit moved the updating of the internal notion of the CA into
the file serialization method; the problem is that that method was only
invoked if the CA was being serialized to disk.

If it wasn't being serialized to disk, if the CA changed it would result
in certmgr triggering the action every time it checked that particular spec.

Without this commit, the only work around is to restart certmgr itself.

This bug affected v1.6.1, v1.6.2, and v1.6.3.