### PR TITLE
Tolerate starting without any specs defined.

### DIFF
--- a/cli/ensure.go
+++ b/cli/ensure.go
@@ -10,6 +10,7 @@ import (
 var ensureTolerance = 3
 var enableActions = false
 var forceRegen = false
+var allowZeroSpecs = false
 
 var ensureCmd = &cobra.Command{
 	Use:   "ensure",
@@ -29,6 +30,11 @@ func Ensure(cmd *cobra.Command, args []string) {
 	err = mgr.Load(false)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed: %s\n", err)
+		os.Exit(1)
+	}
+
+	if !allowZeroSpecs && len(mgr.Certs) == 0 {
+		fmt.Fprint(os.Stderr, "Failed: No specs were found to process\n")
 		os.Exit(1)
 	}
 
@@ -52,4 +58,5 @@ func init() {
 	ensureCmd.Flags().IntVarP(&ensureTolerance, "tries", "n", ensureTolerance, "number of times to retry refreshing a certificate")
 	ensureCmd.Flags().BoolVarP(&enableActions, "enableActions", "", enableActions, "if passed, run the certificates svcmgr actions; defaults to not running them")
 	ensureCmd.Flags().BoolVarP(&forceRegen, "forceRegen", "", forceRegen, "if passed, ignore TTL checks and force regeneration of all specs")
+	ensureCmd.Flags().BoolVarP(&allowZeroSpecs, "allowZeroSpecs", "0", allowZeroSpecs, "if passed, do not return a nonzero exit code if there were no specs found to process; defaults to failing if nothing is found")
 }

--- a/cli/root.go
+++ b/cli/root.go
@@ -18,6 +18,7 @@ import (
 var cfgFile string
 var logLevel string
 var debug, sync bool
+var requireSpecs bool
 
 var manager struct {
 	Dir            string
@@ -44,6 +45,10 @@ func root(cmd *cobra.Command, args []string) {
 	err = mgr.Load(false)
 	if err != nil {
 		log.Fatalf("certmgr: %s", err)
+	}
+
+	if requireSpecs && len(mgr.Certs) == 0 {
+		log.Fatal("certmgr: no specs were found, and --requireSpecs was passed")
 	}
 
 	// bit of a hack- metrics should instead see the mgr
@@ -90,6 +95,7 @@ func init() {
 	RootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "enable debug mode")
 	RootCmd.Flags().BoolVarP(&sync, "sync", "s", false, "the first certificate check should be synchronous")
 	RootCmd.Flags().MarkHidden("sync")
+	RootCmd.Flags().BoolVarP(&requireSpecs, "requireSpecs", "", false, "fail the daemon startup if no specs were found in the directory to watch")
 
 	viper.BindPFlag("dir", RootCmd.PersistentFlags().Lookup("dir"))
 	viper.BindPFlag("svcmgr", RootCmd.PersistentFlags().Lookup("svcmgr"))

--- a/mgr/manager.go
+++ b/mgr/manager.go
@@ -327,7 +327,7 @@ func (m *Manager) Load(forced bool) error {
 	}
 
 	if len(m.Certs) == 0 {
-		return errors.New("manager: no certificate specs found")
+		log.Warning("manager: no certificate specs found")
 	}
 
 	log.Infof("manager: watching %d certificates", len(m.Certs))

--- a/mgr/manager.go
+++ b/mgr/manager.go
@@ -650,7 +650,7 @@ func (m *Manager) Server(sync bool) {
 	if sync {
 		failed := m.CheckCertsSync()
 		if failed != 0 {
-			log.Infof("manager: failed to provision %d certs (certs are queued)")
+			log.Errorf("manager: failed to provision %d certs (certs are queued)")
 		}
 	} else {
 		m.CheckCerts()


### PR DESCRIPTION
Previously, certmgr daemon mode would refuse to run if it couldn't find
any specs to manage; you literally couldn't start the daemon in that
case.

While running it without specs is a bit daft, if one deploys certmgr
as part of a standard fleet image- as an expected service- that behaviour
becomes problematic if the host doesn't (yet) have any specs configured.

Thus this change: it converts "no specs found" into a warning, but
tolerates it for daemon mode.

If folks want the old behaviour, they can pass --requireSpecs to the
daemon invocation and it'll behave as it did before.

Finally, `certmgr ensure` also got a tweak; if you're invoking ensure
directly, you're doing this because there should be specs you want
processed.  That behaviour makes sense, but is now configurable.

If you invoke `certmgr ensure` and it fails to find any specs to process,
that results in a non-zero exit code.

If you want to tolerate no specs being found, you can invoke
`certmgr ensure --allowZeroSpecs` to allow this.

A warning is logged either way, but it'll not fail if no specs were
found and that flag was enabled.