### PR TITLE
Refactoring and bugfixing

### DIFF
--- a/cert/cert.go
+++ b/cert/cert.go
@@ -246,7 +246,6 @@ type Spec struct {
 	// spec.
 	Path string
 
-	queued  bool
 	expires time.Time
 	tr      *transport.Transport
 }
@@ -464,7 +463,10 @@ func (spec *Spec) IsChangedOnDisk(path string) bool {
 
 // Reset the lifespan to force cfssl to regenerate
 func (spec *Spec) ResetLifespan() {
-	spec.tr.Provider.Certificate().NotAfter = time.Time{}
+	cert := spec.tr.Provider.Certificate()
+	if cert != nil {
+		spec.tr.Provider.Certificate().NotAfter = time.Time{}
+	}
 }
 
 // Certificate returns the x509.Certificate associated with the spec
@@ -507,22 +509,6 @@ func (spec *Spec) CAAge() time.Duration {
 	}
 	now := time.Now()
 	return now.Sub(parsedCert.NotBefore)
-}
-
-// Queue marks the spec as being queued for renewal.
-func (spec *Spec) Queue() {
-	spec.queued = true
-}
-
-// IsQueued returns true if the spec is already queued for renewal.
-func (spec *Spec) IsQueued() bool {
-	return spec.queued
-}
-
-// Dequeue marks the spec as having been removed from the renewal
-// queue.
-func (spec *Spec) Dequeue() {
-	spec.queued = false
 }
 
 // Backoff returns the backoff delay.

--- a/cli/ensure.go
+++ b/cli/ensure.go
@@ -44,12 +44,6 @@ func Ensure(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	err = mgr.CheckDiskPKI()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed: %s\n", err)
-		os.Exit(1)
-	}
-
 	fmt.Println("OK")
 }
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -27,16 +27,6 @@ var (
 		[]string{"spec_path", "svcmgr", "cert_action", "cert_age", "ca", "ca_age"},
 	)
 
-	// QueueCount counts the number of certificates actively in
-	// the renewal queue.
-	QueueCount = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "cert_renewal_queue",
-			Help: "number of certificates in the renewal queue",
-		},
-		[]string{"spec_path"},
-	)
-
 	// ExpireNext contains the time of the next certificate
 	// expiry.
 	ExpireNext = prometheus.NewGaugeVec(
@@ -125,7 +115,6 @@ func init() {
 	startTime = time.Now()
 
 	prometheus.MustRegister(WatchCount)
-	prometheus.MustRegister(QueueCount)
 	prometheus.MustRegister(ExpireNext)
 	prometheus.MustRegister(FailureCount)
 	prometheus.MustRegister(AlgorithmMismatchCount)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -149,17 +149,6 @@ var indexPage = `<html>
       <li>Prometheus endpoint: <a href="/metrics"><code>/metrics</code></a></li>
       <li>pprof endpoint: <a href="/debug/pprof"><code>/debug/pprof</code></a></li>
     </ul>
-    <h4>Current metrics:</h4>
-    <ul>
-      <li>Watch count: %d</li>
-      <li>Certs in queue: %d</li>
-      <li>Hours until the next cert expires: %d</li>
-      <li>Number of times a certificate has failed to renew: %d</li>
-    </ul>
-    <h4>Certificates managed by this instance:</h4>
-    <ul>
-%s
-    </ul>
   </body>
 </html>
 `
@@ -167,7 +156,7 @@ var indexPage = `<html>
 func genServeIndex(addr, ilink string, certs string) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		page := fmt.Sprintf(indexPage, startTime.Format("2006-01-02T15:04:05-0700"),
-			addr, ilink, certs)
+			addr, ilink)
 		io.WriteString(w, page)
 	}
 }

--- a/mgr/manager.go
+++ b/mgr/manager.go
@@ -95,6 +95,92 @@ func (spec *CertServiceManager) CheckCA() error {
 	return nil
 }
 
+// CheckDiskPKI checks the PKI information on disk against cert spec and alerts upon differences
+// Specifically, it checks that private key on disk matches spec algorithm & keysize,
+// and certificate on disk matches CSR spec info
+func (csm *CertServiceManager) CheckDiskPKI() error {
+	certPath := csm.Spec.Cert.Path
+	keyPath := csm.Spec.Key.Path
+	specPath := csm.Spec.Path
+	csrRequest := csm.Spec.Request
+
+	// Read private key algorithm and keysize from disk, determine if RSA or ECDSA
+	keyData, err := ioutil.ReadFile(keyPath)
+	if err != nil {
+		return err
+	}
+	pemKey, _ := pem.Decode(keyData)
+	if pemKey == nil {
+		return errors.New("Unable to pem decode private key on disk")
+	}
+
+	var algDisk string
+	var sizeDisk int
+	privKey, err := x509.ParsePKCS1PrivateKey(pemKey.Bytes)
+	if err != nil {
+		privKey, err := x509.ParseECPrivateKey(pemKey.Bytes)
+		if err != nil {
+			// If we get here, then invalid key type
+			return errors.New("manager: Unable to parse private key algorithm from disk")
+		}
+		// If we get here, then it's ECDSA
+		algDisk = "ecdsa"
+		sizeDisk = privKey.Curve.Params().BitSize
+	} else {
+		//If we get here, then it's RSA
+		algDisk = "rsa"
+		sizeDisk = privKey.N.BitLen()
+	}
+
+	// Check algorithm and keysize of private key on disk against what's defined in spec
+	algSpec := csrRequest.KeyRequest.Algo()
+	sizeSpec := csrRequest.KeyRequest.Size()
+
+	if algDisk != algSpec {
+		metrics.AlgorithmMismatchCount.WithLabelValues(specPath).Set(1)
+		log.Errorf("manager: disk alg is %s but spec alg is %s\n", algDisk, algSpec)
+	} else {
+		metrics.AlgorithmMismatchCount.WithLabelValues(specPath).Set(0)
+	}
+
+	if sizeDisk != sizeSpec {
+		metrics.KeysizeMismatchCount.WithLabelValues(specPath).Set(1)
+		log.Errorf("manager: disk key size is %d but spec key size is %d\n", sizeDisk, sizeSpec)
+	} else {
+		metrics.KeysizeMismatchCount.WithLabelValues(specPath).Set(0)
+	}
+
+	// Check that certificate hostnames match spec hostnames
+	certData, err := ioutil.ReadFile(certPath)
+	if err != nil {
+		return err
+	}
+	p, _ := pem.Decode(certData)
+	if p == nil {
+		return errors.New("Unable to pem decode certificate on disk")
+	}
+	cert, err := x509.ParseCertificate(p.Bytes)
+	if err != nil {
+		return err
+	}
+	if !hostnamesEquals(csrRequest.Hosts, cert.DNSNames) {
+		metrics.HostnameMismatchCount.WithLabelValues(specPath).Set(1)
+		log.Errorf("manager: DNS names in cert on disk don't match with hostnames in spec")
+	} else {
+		metrics.HostnameMismatchCount.WithLabelValues(specPath).Set(0)
+	}
+
+	// Check if cert and key are valid pair
+	tlsCert, err := tls.X509KeyPair(certData, keyData)
+	if err != nil || tlsCert.Leaf != nil {
+		metrics.KeypairMismatchCount.WithLabelValues(specPath).Set(1)
+		log.Errorf("manager: Certificate and key on disk are not valid keypair")
+	} else {
+		metrics.KeypairMismatchCount.WithLabelValues(specPath).Set(0)
+	}
+	return nil
+}
+
 // The Manager structure contains the certificates to be managed. A
 // manager needs to be constructed with one of the New functions, and
 // should not be constructed by hand.
@@ -210,101 +296,6 @@ var validExtensions = map[string]bool{
 	".yml":  true,
 }
 
-// CheckDiskPKI checks the PKI information on disk against cert spec and alerts upon differences
-// Specifically, it checks that private key on disk matches spec algorithm & keysize,
-// and certificate on disk matches CSR spec info
-func (m *Manager) CheckDiskPKI() error {
-
-	if m.Certs == nil || len(m.Certs) == 0 {
-		return nil
-	}
-
-	// Iterate through certificates. Compare what's on disk to what's structurally stored
-	for i := range m.Certs {
-		csm := m.Certs[i]
-		certPath := csm.Spec.Cert.Path
-		keyPath := csm.Spec.Key.Path
-		specPath := csm.Spec.Path
-		csrRequest := csm.Spec.Request
-
-		// Read private key algorithm and keysize from disk, determine if RSA or ECDSA
-		keyData, err := ioutil.ReadFile(keyPath)
-		if err != nil {
-			return err
-		}
-		pemKey, _ := pem.Decode(keyData)
-		if pemKey == nil {
-			return errors.New("Unable to pem decode private key on disk")
-		}
-
-		var algDisk string
-		var sizeDisk int
-		privKey, err := x509.ParsePKCS1PrivateKey(pemKey.Bytes)
-		if err != nil {
-			privKey, err := x509.ParseECPrivateKey(pemKey.Bytes)
-			if err != nil {
-				// If we get here, then invalid key type
-				return errors.New("manager: Unable to parse private key algorithm from disk")
-			}
-			// If we get here, then it's ECDSA
-			algDisk = "ecdsa"
-			sizeDisk = privKey.Curve.Params().BitSize
-		} else {
-			//If we get here, then it's RSA
-			algDisk = "rsa"
-			sizeDisk = privKey.N.BitLen()
-		}
-
-		// Check algorithm and keysize of private key on disk against what's defined in spec
-		algSpec := csrRequest.KeyRequest.Algo()
-		sizeSpec := csrRequest.KeyRequest.Size()
-
-		if algDisk != algSpec {
-			metrics.AlgorithmMismatchCount.WithLabelValues(specPath).Set(1)
-			log.Errorf("manager: disk alg is %s but spec alg is %s\n", algDisk, algSpec)
-		} else {
-			metrics.AlgorithmMismatchCount.WithLabelValues(specPath).Set(0)
-		}
-
-		if sizeDisk != sizeSpec {
-			metrics.KeysizeMismatchCount.WithLabelValues(specPath).Set(1)
-			log.Errorf("manager: disk key size is %d but spec key size is %d\n", sizeDisk, sizeSpec)
-		} else {
-			metrics.KeysizeMismatchCount.WithLabelValues(specPath).Set(0)
-		}
-
-		// Check that certificate hostnames match spec hostnames
-		certData, err := ioutil.ReadFile(certPath)
-		if err != nil {
-			return err
-		}
-		p, _ := pem.Decode(certData)
-		if p == nil {
-			return errors.New("Unable to pem decode certificate on disk")
-		}
-		cert, err := x509.ParseCertificate(p.Bytes)
-		if err != nil {
-			return err
-		}
-		if !hostnamesEquals(csrRequest.Hosts, cert.DNSNames) {
-			metrics.HostnameMismatchCount.WithLabelValues(specPath).Set(1)
-			log.Errorf("manager: DNS names in cert on disk don't match with hostnames in spec")
-		} else {
-			metrics.HostnameMismatchCount.WithLabelValues(specPath).Set(0)
-		}
-
-		// Check if cert and key are valid pair
-		tlsCert, err := tls.X509KeyPair(certData, keyData)
-		if err != nil || tlsCert.Leaf != nil {
-			metrics.KeypairMismatchCount.WithLabelValues(specPath).Set(1)
-			log.Errorf("manager: Certificate and key on disk are not valid keypair")
-		} else {
-			metrics.KeypairMismatchCount.WithLabelValues(specPath).Set(0)
-		}
-	}
-	return nil
-}
-
 // Compare if hostnames in certificate and spec are equal
 func hostnamesEquals(a, b []string) bool {
 	if len(a) != len(b) {
@@ -408,7 +399,12 @@ func (m *Manager) CheckCerts() {
 
 	log.Info("manager: checking certificates")
 	for i := range m.Certs {
-		if err := m.Certs[i].CheckCA(); err != nil {
+		err := m.Certs[i].CheckDiskPKI()
+		if err != nil {
+			log.Debugf("manager: spec %s, checkdiskpki: %s", m.Certs[i], err.Error())
+		}
+
+		if err = m.Certs[i].CheckCA(); err != nil {
 			log.Errorf("manager: the CA for %s has changed, but the service couldn't be notified of the change", m.Certs[i])
 		}
 
@@ -451,7 +447,12 @@ func (m *Manager) MustCheckCerts(tolerance int, enableActions bool, forceRegen b
 
 	var queue = make(chan *queuedCert, len(m.Certs))
 	for i := range m.Certs {
-		if err := m.Certs[i].CheckCA(); err != nil {
+		err := m.Certs[i].CheckDiskPKI()
+		if err != nil {
+			log.Debugf("manager: spec %s, checkdiskpki: %s", m.Certs[i], err.Error())
+		}
+
+		if err = m.Certs[i].CheckCA(); err != nil {
 			log.Errorf("manager: the CA for %s has changed, but the service couldn't be notified of the change", m.Certs[i])
 		}
 
@@ -604,11 +605,6 @@ func (m *Manager) Server() {
 
 	m.CheckCerts()
 
-	err := m.CheckDiskPKI()
-	if err != nil {
-		log.Debugf("manager: checkdiskpki: %s", err.Error())
-	}
-
 	for {
 		<-time.After(m.interval)
 
@@ -624,10 +620,6 @@ func (m *Manager) Server() {
 		}
 
 		m.CheckCerts()
-		err := m.CheckDiskPKI()
-		if err != nil {
-			log.Debugf("manager: checkdiskpki: %s", err.Error())
-		}
 		m.SetExpiresNext()
 	}
 }


### PR DESCRIPTION
Roughly:
1) minor metric related fixes.  Convert WatchCount to a gauge (since it can go in reverse), and fix the / index.  Additionally, force a namespace so all certmgr specific metrics are prefixed with 'certmgr_'.
2) Refactor and gut duplication in mgr/manager.go.  Specifically eliminate the queue architecture since it broke encapsulation, move relevant methods to relevant instances, and simplify processing so that wake intervals are actually synchronous in execution and evaluation.

The refactoring should be transparent to end users; it's just code cleanup.