### PR TITLE
Require yaml for certmgr.yaml, drop dead code, enhance metrics

### DIFF
--- a/cert/cert.go
+++ b/cert/cert.go
@@ -331,7 +331,7 @@ func (spec *Spec) Identity() (*core.Identity, error) {
 	return ident, nil
 }
 
-func readCertFile(path string) (*Spec, error) {
+func newSpecFromPath(path string) (*Spec, error) {
 	in, err := ioutil.ReadFile(path)
 	if err != nil {
 		return nil, err
@@ -356,7 +356,7 @@ func readCertFile(path string) (*Spec, error) {
 
 // Load reads a spec from a JSON configuration file.
 func Load(path, remote string, before time.Duration) (*Spec, error) {
-	spec, err := readCertFile(path)
+	spec, err := newSpecFromPath(path)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/root.go
+++ b/cli/root.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/cloudflare/certmgr/cert"
 	"github.com/cloudflare/certmgr/metrics"
@@ -23,7 +24,7 @@ var requireSpecs bool
 var manager struct {
 	Dir            string
 	ServiceManager string
-	Before         string
+	Before         time.Duration
 }
 
 func newManager() (*mgr.Manager, error) {
@@ -31,8 +32,8 @@ func newManager() (*mgr.Manager, error) {
 		viper.GetString("dir"),
 		viper.GetString("default_remote"),
 		viper.GetString("svcmgr"),
-		viper.GetString("before"),
-		viper.GetString("interval"),
+		viper.GetDuration("before"),
+		viper.GetDuration("interval"),
 	)
 }
 
@@ -91,7 +92,7 @@ func init() {
 	}
 	sort.Strings(backends)
 	RootCmd.PersistentFlags().StringVarP(&manager.ServiceManager, "svcmgr", "m", "", fmt.Sprintf("service manager, must be one of: %s", strings.Join(backends, ", ")))
-	RootCmd.PersistentFlags().StringVarP(&manager.Before, "before", "t", "", "how long before certificates expire to start renewing (in the form Nh)")
+	RootCmd.PersistentFlags().DurationVarP(&manager.Before, "before", "t", time.Hour * 72, "how long before certificates expire to start renewing (in duration format)")
 	RootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "enable debug mode")
 	RootCmd.Flags().BoolVarP(&requireSpecs, "requireSpecs", "", false, "fail the daemon startup if no specs were found in the directory to watch")
 

--- a/cli/root.go
+++ b/cli/root.go
@@ -25,6 +25,7 @@ var manager struct {
 	Dir            string
 	ServiceManager string
 	Before         time.Duration
+	Interval       time.Duration
 }
 
 func newManager() (*mgr.Manager, error) {
@@ -92,13 +93,15 @@ func init() {
 	}
 	sort.Strings(backends)
 	RootCmd.PersistentFlags().StringVarP(&manager.ServiceManager, "svcmgr", "m", "", fmt.Sprintf("service manager, must be one of: %s", strings.Join(backends, ", ")))
-	RootCmd.PersistentFlags().DurationVarP(&manager.Before, "before", "t", time.Hour * 72, "how long before certificates expire to start renewing (in duration format)")
+	RootCmd.PersistentFlags().DurationVarP(&manager.Before, "before", "t", mgr.DefaultBefore, "how long before certificates expire to start renewing (in duration format)")
+	RootCmd.PersistentFlags().DurationVarP(&manager.Interval, "interval", "i", mgr.DefaultInterval, "how long to sleep before checking for renewal (in duration format)")
 	RootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "enable debug mode")
 	RootCmd.Flags().BoolVarP(&requireSpecs, "requireSpecs", "", false, "fail the daemon startup if no specs were found in the directory to watch")
 
 	viper.BindPFlag("dir", RootCmd.PersistentFlags().Lookup("dir"))
 	viper.BindPFlag("svcmgr", RootCmd.PersistentFlags().Lookup("svcmgr"))
 	viper.BindPFlag("before", RootCmd.PersistentFlags().Lookup("before"))
+	viper.BindPFlag("interval", RootCmd.PersistentFlags().Lookup("interval"))
 	viper.BindPFlag("debug", RootCmd.PersistentFlags().Lookup("debug"))
 }
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -27,18 +27,18 @@ var (
 			Name:      "specs_watched_total",
 			Help:      "Number of specs being watched",
 		},
-		[]string{"spec_path", "svcmgr", "cert_action", "cert_age", "ca", "ca_age"},
+		[]string{"spec_path", "svcmgr", "action", "ca"},
 	)
 
 	// ExpireNext contains the time of the next certificate
 	// expiry.
-	ExpireNext = prometheus.NewGaugeVec(
+	Expires = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: metricsNamespace,
-			Name:      "cert_next_expires",
-			Help:      "the number of hours until the next certificate expires",
+			Name:      "cert_expire_timestamp",
+			Help:      "The unix time for when the given spec and type expires",
 		},
-		[]string{"spec_path"},
+		[]string{"spec_path", "type"},
 	)
 
 	// FailureCount contains a count of the number of failures to
@@ -126,8 +126,8 @@ var (
 func init() {
 	startTime = time.Now()
 
-	prometheus.MustRegister(WatchCount)
-	prometheus.MustRegister(ExpireNext)
+	prometheus.MustRegister(SpecWatchCount)
+	prometheus.MustRegister(Expires)
 	prometheus.MustRegister(FailureCount)
 	prometheus.MustRegister(AlgorithmMismatchCount)
 	prometheus.MustRegister(KeysizeMismatchCount)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -20,12 +20,12 @@ const metricsNamespace = "certmgr"
 var (
 	startTime time.Time
 
-	// WatchCount counts the number of certificates being watched.
-	WatchCount = prometheus.NewGaugeVec(
-		prometheus.CounterOpts{
+	// SpecWatchCount counts the number of specs being watched.
+	SpecWatchCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
 			Namespace: metricsNamespace,
-			Name:      "cert_watching",
-			Help:      "Number of certificates being watched",
+			Name:      "specs_watched_total",
+			Help:      "Number of specs being watched",
 		},
 		[]string{"spec_path", "svcmgr", "cert_action", "cert_age", "ca", "ca_age"},
 	)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -96,10 +96,10 @@ var (
 	ManagerInterval = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: metricsNamespace,
-			Name:      "manager_interval",
+			Name:      "manager_interval_seconds",
 			Help:      "the time interval that manager wakes up and does checks",
 		},
-		[]string{"directory", "interval"},
+		[]string{"directory"},
 	)
 
 	// ActionCount counts actions taken by spec

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -15,14 +15,17 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
+const metricsNamespace = "certmgr"
+
 var (
 	startTime time.Time
 
 	// WatchCount counts the number of certificates being watched.
-	WatchCount = prometheus.NewCounterVec(
+	WatchCount = prometheus.NewGaugeVec(
 		prometheus.CounterOpts{
-			Name: "cert_watching",
-			Help: "Number of certificates being watched",
+			Namespace: metricsNamespace,
+			Name:      "cert_watching",
+			Help:      "Number of certificates being watched",
 		},
 		[]string{"spec_path", "svcmgr", "cert_action", "cert_age", "ca", "ca_age"},
 	)
@@ -31,8 +34,9 @@ var (
 	// expiry.
 	ExpireNext = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "cert_next_expires",
-			Help: "the number of hours until the next certificate expires",
+			Namespace: metricsNamespace,
+			Name:      "cert_next_expires",
+			Help:      "the number of hours until the next certificate expires",
 		},
 		[]string{"spec_path"},
 	)
@@ -41,8 +45,9 @@ var (
 	// generate a key pair or renew a certificate.
 	FailureCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "cert_renewal_failures",
-			Help: "Number of keypair generation or cert renewal failures",
+			Namespace: metricsNamespace,
+			Name:      "cert_renewal_failures",
+			Help:      "Number of keypair generation or cert renewal failures",
 		},
 		[]string{"spec_path"},
 	)
@@ -50,8 +55,9 @@ var (
 	// AlgorithmMismatchCount counts mismatches occurred between algorithm on disk vs algorithm in spec
 	AlgorithmMismatchCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "algorithm_mismatch",
-			Help: "Number of mismatches between cert algorithm on disk vs algorithm specified in spec",
+			Namespace: metricsNamespace,
+			Name:      "algorithm_mismatch",
+			Help:      "Number of mismatches between cert algorithm on disk vs algorithm specified in spec",
 		},
 		[]string{"spec_path"},
 	)
@@ -59,8 +65,9 @@ var (
 	// KeysizeMismatchCount counts mismatches occurred between keysize on disk vs keysize in spec
 	KeysizeMismatchCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "keysize_mismatch",
-			Help: "Number of mismatches between keysize disk vs keysize specified in spec",
+			Namespace: metricsNamespace,
+			Name:      "keysize_mismatch",
+			Help:      "Number of mismatches between keysize disk vs keysize specified in spec",
 		},
 		[]string{"spec_path"},
 	)
@@ -68,8 +75,9 @@ var (
 	// HostnameMismatchCount counts mismatches occurred between cert hostnames on disk vs cert hostnames in spec
 	HostnameMismatchCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "hostname_mismatch",
-			Help: "Number of mismatches between cert hostnames on disk vs cert hostnames specified in spec",
+			Namespace: metricsNamespace,
+			Name:      "hostname_mismatch",
+			Help:      "Number of mismatches between cert hostnames on disk vs cert hostnames specified in spec",
 		},
 		[]string{"spec_path"},
 	)
@@ -77,8 +85,9 @@ var (
 	// KeypairMismatchCount counts TLS mismatch between key and certificate on disk
 	KeypairMismatchCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "keypair_mismatch",
-			Help: "Number of TLS mismatches between key and certificate on disk",
+			Namespace: metricsNamespace,
+			Name:      "keypair_mismatch",
+			Help:      "Number of TLS mismatches between key and certificate on disk",
 		},
 		[]string{"spec_path"},
 	)
@@ -86,8 +95,9 @@ var (
 	// ManagerInterval is set to the interval at which a cert manager wakes up and does its checks
 	ManagerInterval = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "manager_interval",
-			Help: "the time interval that manager wakes up and does checks",
+			Namespace: metricsNamespace,
+			Name:      "manager_interval",
+			Help:      "the time interval that manager wakes up and does checks",
 		},
 		[]string{"directory", "interval"},
 	)
@@ -95,8 +105,9 @@ var (
 	// ActionCount counts actions taken by spec
 	ActionCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "action_count",
-			Help: "Number of times a spec has taken action",
+			Namespace: metricsNamespace,
+			Name:      "action_count",
+			Help:      "Number of times a spec has taken action",
 		},
 		[]string{"spec_path", "change_type"},
 	)
@@ -104,8 +115,9 @@ var (
 	// ActionFailure counts number of times an action taken by spec failed
 	ActionFailure = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "action_failure",
-			Help: "Number of times a spec's action has failed",
+			Namespace: metricsNamespace,
+			Name:      "action_failure",
+			Help:      "Number of times a spec's action has failed",
 		},
 		[]string{"spec_path", "change_type"},
 	)

--- a/mgr/manager.go
+++ b/mgr/manager.go
@@ -409,7 +409,7 @@ func (m *Manager) Load(forced bool) error {
 			return err
 		}
 		m.Certs = append(m.Certs, &CertServiceManager{cert, manager})
-		metrics.WatchCount.WithLabelValues(cert.Path, s, cert.Action, cert.CertificateAge().String(), cert.CA.Label, cert.CAAge().String()).Inc()
+		metrics.SpecWatchCount.WithLabelValues(cert.Path, s, cert.Action, cert.CertificateAge().String(), cert.CA.Label, cert.CAAge().String()).Inc()
 		return nil
 	}
 

--- a/mgr/manager.go
+++ b/mgr/manager.go
@@ -452,7 +452,7 @@ func (m *Manager) Server() {
 	// updating the next expiration independently of checking
 	// certificates.
 
-	metrics.ManagerInterval.WithLabelValues(m.Dir, m.Interval).Set(1)
+	metrics.ManagerInterval.WithLabelValues(m.Dir).Set(m.interval.Seconds())
 
 	m.CheckCerts()
 


### PR DESCRIPTION
Refactoring work:
1) certmgr.yaml tried to support json.  This lead to code complications and gaps- instead, just require yaml and use a proper UnmarshallYAML method to simplify invocation paths and remove variable shadowing on the manager structure (having before and Before for example).
2) rename readCertFile to NewSpecFromFile since it's actually reading a spec.
3) Drop more dead methods via cleanup metric work below.

Metrics work:
1) put all metrics in a common `certmgr` namespace.  This ensures they're prefixed with `certmgr_`.
2) refactor the 'age' labeling of specs_watched_total into cert_expire_timestamp; this now gives us a timestamp metric for when both the CA and cert will expire.
3) Expose the manager wake interval value as a metric value rather than label.

For the various "convert time from a label to a metric"- promql functions are such that timestamps as a metric value are fairly well supported; having them as a label blocks our ability to do things like "trigger an alert if we're less than the interval away from a cert expiring and we keep failing to regenerate it" for e
example.

Note: more work is to follow, this is just the next batch.  For explicit details about individual changes, the commit messages are detailed- I'd suggest tracing there if interested.