### PR TITLE
govet/golint cleanup, make cli/* internals private

### DIFF
--- a/cert/spec.go
+++ b/cert/spec.go
@@ -258,6 +258,7 @@ func (spec *Spec) Lifespan() time.Duration {
 	return spec.tr.Lifespan()
 }
 
+// IsChangedOnDisk method to report if the given path is older than the spec
 func (spec *Spec) IsChangedOnDisk(path string) bool {
 	specStat, err := os.Stat(spec.Path)
 	if err != nil {
@@ -320,16 +321,14 @@ func (spec *Spec) CheckDiskPKI() error {
 	if algDisk != algSpec {
 		metrics.AlgorithmMismatchCount.WithLabelValues(spec.Path).Set(1)
 		return fmt.Errorf("manager: disk alg is %s but spec alg is %s\n", algDisk, algSpec)
-	} else {
-		metrics.AlgorithmMismatchCount.WithLabelValues(spec.Path).Set(0)
 	}
+	metrics.AlgorithmMismatchCount.WithLabelValues(spec.Path).Set(0)
 
 	if sizeDisk != sizeSpec {
 		metrics.KeysizeMismatchCount.WithLabelValues(spec.Path).Set(1)
 		return fmt.Errorf("manager: disk key size is %d but spec key size is %d\n", sizeDisk, sizeSpec)
-	} else {
-		metrics.KeysizeMismatchCount.WithLabelValues(spec.Path).Set(0)
 	}
+	metrics.KeysizeMismatchCount.WithLabelValues(spec.Path).Set(0)
 
 	// Check that certificate hostnames match spec hostnames
 	certData, err := ioutil.ReadFile(certPath)
@@ -347,18 +346,16 @@ func (spec *Spec) CheckDiskPKI() error {
 	if !hostnamesEquals(csrRequest.Hosts, cert.DNSNames) {
 		metrics.HostnameMismatchCount.WithLabelValues(spec.Path).Set(1)
 		return errors.New("manager: DNS names in cert on disk don't match with hostnames in spec")
-	} else {
-		metrics.HostnameMismatchCount.WithLabelValues(spec.Path).Set(0)
 	}
+	metrics.HostnameMismatchCount.WithLabelValues(spec.Path).Set(0)
 
 	// Check if cert and key are valid pair
 	tlsCert, err := tls.X509KeyPair(certData, keyData)
 	if err != nil || tlsCert.Leaf != nil {
 		metrics.KeypairMismatchCount.WithLabelValues(spec.Path).Set(1)
 		return fmt.Errorf("manager: Certificate and key on disk are not valid keypair: %s", err)
-	} else {
-		metrics.KeypairMismatchCount.WithLabelValues(spec.Path).Set(0)
 	}
+	metrics.KeypairMismatchCount.WithLabelValues(spec.Path).Set(0)
 	return nil
 }
 
@@ -393,7 +390,7 @@ func (spec *Spec) CAExpireTime() time.Time {
 	return parsedCert.NotAfter
 }
 
-// Reset the lifespan to force cfssl to regenerate
+// ResetLifespan Reset the lifespan to force cfssl to regenerate
 func (spec *Spec) ResetLifespan() {
 	cert := spec.tr.Provider.Certificate()
 	if cert != nil {

--- a/cli/check.go
+++ b/cli/check.go
@@ -15,10 +15,10 @@ and validate the certificate specs. Note that this will verify that
 the CA certificate can be fetched from the remote CA, but it doesn't
 verify that the authentication key is valid, as this is currently only
 checkable during the certificate provisioning process.`,
-	Run: Check,
+	Run: check,
 }
 
-func Check(cmd *cobra.Command, args []string) {
+func check(cmd *cobra.Command, args []string) {
 	mgr, err := newManager()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed: %s\n", err)

--- a/cli/ensure.go
+++ b/cli/ensure.go
@@ -17,10 +17,10 @@ var ensureCmd = &cobra.Command{
 	Short: "Ensure all certificate specs have matching keypairs.",
 	Long: `Certificate manager will load all certificate specs, and ensure that the
 TLS key pairs they identify exist, are valid, and that they are up-to-date.`,
-	Run: Ensure,
+	Run: ensure,
 }
 
-func Ensure(cmd *cobra.Command, args []string) {
+func ensure(cmd *cobra.Command, args []string) {
 	mgr, err := newManager()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed: %s\n", err)

--- a/cli/root.go
+++ b/cli/root.go
@@ -69,6 +69,7 @@ func root(cmd *cobra.Command, args []string) {
 	mgr.Server(strict)
 }
 
+// RootCmd this is our command processor for CLI interactions
 var RootCmd = &cobra.Command{
 	Use:   "certmgr",
 	Short: "Manage TLS certificates for multiple services",
@@ -76,6 +77,7 @@ var RootCmd = &cobra.Command{
 	Run:   root,
 }
 
+// Execute execute our argument parser
 func Execute() {
 	if err := RootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -29,7 +29,7 @@ var (
 		[]string{"spec_path", "svcmgr", "action", "ca"},
 	)
 
-	// ExpireNext contains the time of the next certificate
+	// Expires contains the time of the next certificate
 	// expiry.
 	Expires = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{

--- a/svcmgr/command.go
+++ b/svcmgr/command.go
@@ -16,13 +16,13 @@ type commandManager struct {
 	command string
 }
 
-func (cm commandManager) TakeAction(change_type string, spec_path string, ca_path string, cert_path string, key_path string) error {
+func (cm commandManager) TakeAction(changeType string, specPath string, caPath string, certPath string, keyPath string) error {
 	env := []string{
-		"CERTMGR_CA_PATH=" + ca_path,
-		"CERTMGR_CERT_PATH=" + cert_path,
-		"CERTMGR_KEY_PATH=" + key_path,
-		"CERTMGR_SPEC_PATH=" + spec_path,
-		"CERTMGR_CHANGE_TYPE=" + change_type,
+		"CERTMGR_CA_PATH=" + caPath,
+		"CERTMGR_CERT_PATH=" + certPath,
+		"CERTMGR_KEY_PATH=" + keyPath,
+		"CERTMGR_SPEC_PATH=" + specPath,
+		"CERTMGR_CHANGE_TYPE=" + changeType,
 	}
 	return runEnv(env, shellBinary, "-c", cm.command)
 }


### PR DESCRIPTION
Brought variable naming in alignment with standards, added missing
docstrings for exported members, and in general, mangled a lot.

I'm starting to appreciate that the next version of certmgr will
allow us to break API; this cleanup has been a long time coming.