### PR TITLE
Refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # certmgr
 
 [![Build Status](https://travis-ci.org/cloudflare/certmgr.svg?branch=master)](https://travis-ci.org/cloudflare/certmgr)
+[![godoc](https://godoc.org/github.com/cloudflare/certmgr?status.svg)](https://godoc.org/github.com/cloudflare/certmgr)]
 
 certmgr is a tool for managing certificates using CFSSL. It does the
 following:

--- a/cert/ca.go
+++ b/cert/ca.go
@@ -34,15 +34,15 @@ type CA struct {
 	pem         []byte
 }
 
-// GetPEM is for testing only!
+// getPEM is for testing only!
 // Getter for CA cert PEM
-func (ca *CA) GetPEM() []byte {
+func (ca *CA) getPEM() []byte {
 	return ca.pem
 }
 
-// SetPEM is for testing only!
+// setPEM is for testing only!
 // Setter for CA cert PEM
-func (ca *CA) SetPEM(pem []byte) {
+func (ca *CA) setPEM(pem []byte) {
 	ca.pem = pem
 }
 

--- a/cert/ca.go
+++ b/cert/ca.go
@@ -8,10 +8,8 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/cloudflare/cfssl/api/client"
@@ -88,17 +86,11 @@ func (ca *CA) writeCert(cert []byte) error {
 		return nil
 	}
 
-	ca.File.Path = filepath.Clean(ca.File.Path)
-	err := ca.File.Parse(fmt.Sprintf("CA:%s/%s/%s", ca.Remote, ca.Label, ca.Profile))
-	if err != nil {
-		return err
-	}
-
 	// add a trailing newline for humans
 	if !bytes.HasSuffix(cert, []byte{'\n'}) {
 		cert = append(cert, '\n')
 	}
-	err = ioutil.WriteFile(ca.File.Path, cert, 0644)
+	err := ioutil.WriteFile(ca.File.Path, cert, 0644)
 	if err != nil {
 		return err
 	}

--- a/cert/ca.go
+++ b/cert/ca.go
@@ -96,8 +96,7 @@ func (ca *CA) writeCert(cert []byte) error {
 	}
 	log.Infof("cert: wrote CA certificate: %s", ca.File.Path)
 
-	err = ca.File.Set()
-	return err
+	return ca.File.setPermissions()
 }
 
 // Load reads the CA certificate from the configured remote, and if a

--- a/cert/cert_test.go
+++ b/cert/cert_test.go
@@ -47,9 +47,9 @@ func TestCompareCertificatesNewlines(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			ca1.SetPEM(googlePem)
-			ca2.SetPEM(newlinePem)
-			isSame, err := CompareCertificates(ca1.GetPEM(), ca2.GetPEM())
+			ca1.setPEM(googlePem)
+			ca2.setPEM(newlinePem)
+			isSame, err := CompareCertificates(ca1.getPEM(), ca2.getPEM())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -71,9 +71,9 @@ func TestCompareCertificateDifferent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ca1.SetPEM(googlePem)
-	ca2.SetPEM(digicertPem)
-	isSame, err := CompareCertificates(ca1.GetPEM(), ca2.GetPEM())
+	ca1.setPEM(googlePem)
+	ca2.setPEM(digicertPem)
+	isSame, err := CompareCertificates(ca1.getPEM(), ca2.getPEM())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,9 +88,9 @@ func TestCompareCertificateNil(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ca1.SetPEM(digicertPem)
-	ca2.SetPEM(nil)
-	isSame, err := CompareCertificates(ca1.GetPEM(), ca2.GetPEM())
+	ca1.setPEM(digicertPem)
+	ca2.setPEM(nil)
+	isSame, err := CompareCertificates(ca1.getPEM(), ca2.getPEM())
 	if strings.Compare(err.Error(), "Unable to pem decode certificate") != 0 || isSame {
 		t.Fatal(err)
 	}
@@ -102,9 +102,9 @@ func TestCompareCertificateEmpty(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ca1.SetPEM(googlePem)
-	ca2.SetPEM([]byte{})
-	isSame, err := CompareCertificates(ca1.GetPEM(), ca2.GetPEM())
+	ca1.setPEM(googlePem)
+	ca2.setPEM([]byte{})
+	isSame, err := CompareCertificates(ca1.getPEM(), ca2.getPEM())
 	if strings.Compare(err.Error(), "Unable to pem decode certificate") != 0 || isSame {
 		t.Fatal(err)
 	}

--- a/cert/file.go
+++ b/cert/file.go
@@ -123,7 +123,7 @@ func (f *File) parse() (err error) {
 }
 
 // Set ensures the file has the right owner/group and mode.
-func (f *File) Set() error {
+func (f *File) setPermissions() error {
 	st, err := os.Stat(f.Path)
 	if err != nil {
 		return err
@@ -144,8 +144,8 @@ func (f *File) Set() error {
 	return nil
 }
 
-// Remove deletes the file specified by the Path field.
-func (f *File) Remove() error {
+// Unlink deletes the file specified by the Path field.
+func (f *File) Unlink() error {
 	log.Debugf("removing %s", f.Path)
 	err := os.Remove(f.Path)
 	if os.IsNotExist(err) {

--- a/cert/spec.go
+++ b/cert/spec.go
@@ -18,6 +18,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/cloudflare/certmgr/metrics"
+	"github.com/cloudflare/certmgr/svcmgr"
 	"github.com/cloudflare/cfssl/csr"
 	"github.com/cloudflare/cfssl/log"
 	"github.com/cloudflare/cfssl/transport"
@@ -32,7 +33,9 @@ type Spec struct {
 	// globally rather than per cert- it's allowed here to allow cert
 	// definitions to use a servicemanager of 'command' to allow freeform
 	// invocations.
-	ServiceManager string `json:"svcmgr" yaml:"svcmgr"`
+	ServiceManagerName string `json:"svcmgr" yaml:"svcmgr"`
+
+	serviceManager svcmgr.Manager
 
 	// The service is the service that uses this certificate. If
 	// this field is not empty, the action below will be applied
@@ -65,16 +68,19 @@ type Spec struct {
 }
 
 func (spec *Spec) String() string {
-	name := displayName(spec.Request.Name())
-	if name == "" {
-		name = spec.Service
+	extra := displayName(spec.Request.Name())
+	if extra == "" {
+		extra = spec.Service
 	}
 
-	if name == "" {
-		name = spec.Cert.Path
+	if extra == "" {
+		extra = spec.Cert.Path
+	}
+	if extra != "" {
+		return fmt.Sprintf("spec: %s: %s", spec.Cert.Path, extra)
 	}
 
-	return name
+	return fmt.Sprintf("spec: %s", spec.Cert.Path)
 }
 
 // Identity creates a transport package identity for the certificate.
@@ -126,7 +132,7 @@ func (spec *Spec) Identity() (*core.Identity, error) {
 	return ident, nil
 }
 
-func newSpecFromPath(path string) (*Spec, error) {
+func newSpecFromPath(path string, defaultServiceManager string) (*Spec, error) {
 	in, err := ioutil.ReadFile(path)
 	if err != nil {
 		return nil, err
@@ -150,8 +156,8 @@ func newSpecFromPath(path string) (*Spec, error) {
 }
 
 // Load reads a spec from a JSON configuration file.
-func Load(path, remote string, before time.Duration) (*Spec, error) {
-	spec, err := newSpecFromPath(path)
+func Load(path, remote string, before time.Duration, defaultServiceManager string, strict bool) (*Spec, error) {
+	spec, err := newSpecFromPath(path, defaultServiceManager)
 	if err != nil {
 		return nil, err
 	}
@@ -198,6 +204,23 @@ func Load(path, remote string, before time.Duration) (*Spec, error) {
 		err = nil
 	}
 
+	manager, _ := svcmgr.New("dummy", "", "")
+	if spec.Action != "" && spec.Action != "nop" {
+		manager, err = svcmgr.New(spec.ServiceManagerName, spec.Action, spec.Service)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// If action is undefined and svcmgr isn't dummy, we will throw a warning due to likely undefined cert renewal behavior
+	// We will refuse to even store/keep track of the cert if we're in strict mode
+	if (spec.Action == "" || spec.Action == "nop") && (spec.ServiceManagerName != "" && spec.ServiceManagerName != "dummy") {
+		log.Warningf("manager: No action defined for a non-dummy svcmgr in certificate spec. This can lead to undefined certificate renewal behavior.")
+		if strict {
+			return nil, nil
+		}
+	}
+	spec.serviceManager = manager
 	return spec, err
 }
 
@@ -416,4 +439,122 @@ func (spec *Spec) Backoff() time.Duration {
 // ResetBackoff resets the spec's backoff.
 func (spec *Spec) ResetBackoff() {
 	spec.tr.Backoff.Reset()
+}
+
+// EnforcePKI Process a spec updating content on disk, taking action as needed.
+// Returns (TTL for PKI, error).  If an error occurs, the ttl is at best
+// a hint to the invoker as to when the next refresh is required- that said
+// the invoker should back off and try a refresh.
+func (spec *Spec) EnforcePKI(enableActions bool) (time.Duration, error) {
+	err := spec.CheckDiskPKI()
+	if err != nil {
+		log.Debugf("manager: %s, checkdiskpki: %s.  Forcing refresh.", spec, err.Error())
+		spec.ResetLifespan()
+	}
+
+	if err = spec.CheckCA(); err != nil {
+		log.Errorf("manager: the CA for %s has changed, but the service couldn't be notified of the change", spec)
+	}
+
+	lifespan := time.Duration(0)
+	if !spec.Ready() {
+		log.Debugf("manager: %s isn't ready", spec)
+	} else {
+		log.Debugf("manager: %s checking lifespan", spec)
+		lifespan = spec.Lifespan()
+	}
+	log.Debugf("manager: %s has lifespan %s", spec, lifespan)
+	if lifespan <= 0 {
+		err := spec.RenewPKI()
+		if err != nil {
+			log.Errorf("manager: failed to renew %s; requeuing cert", spec)
+			return 0, err
+		}
+
+		log.Debug("taking action due to key refresh")
+		if enableActions {
+			err = spec.TakeAction("key")
+		} else {
+			log.Infof("skipping actions for %s due to calling mode", spec)
+		}
+
+		// Even though there was an error managing the service
+		// associated with the certificate, the certificate has been
+		// renewed.
+		if err != nil {
+			metrics.ActionFailure.WithLabelValues(spec.Path, "key").Inc()
+			log.Errorf("manager: %s", err)
+		}
+
+		log.Info("manager: certificate successfully processed")
+	}
+	metrics.Expires.WithLabelValues(spec.Path, "cert").Set(float64(spec.CertExpireTime().Unix()))
+
+	return spec.Lifespan(), nil
+}
+
+// TakeAction execute the configured svcmgr Action for this spec
+func (spec *Spec) TakeAction(changeType string) error {
+	log.Infof("manager: executing configured action due to change type %s for %s", changeType, spec.Cert.Path)
+	caPath := ""
+	if spec.CA.File != nil {
+		caPath = spec.CA.File.Path
+	}
+	metrics.ActionCount.WithLabelValues(spec.Cert.Path, changeType).Inc()
+	return spec.serviceManager.TakeAction(changeType, spec.Path, caPath, spec.Cert.Path, spec.Key.Path)
+}
+
+// The maximum number of attempts before giving up.
+const maxAttempts = 5
+
+// RenewPKI Try to update the on disk PKI content with a fresh CA/cert as needed
+func (spec *Spec) RenewPKI() error {
+	start := time.Now()
+	for attempts := 0; attempts < maxAttempts; attempts++ {
+		log.Infof("manager: processing certificate %s (attempt %d)", spec, attempts+1)
+		err := spec.RefreshKeys()
+		if err != nil {
+			if isAuthError(err) {
+				// Killing the server is really the
+				// only valid option here; it will
+				// force an investigation into why the
+				// auth key is bad.
+				log.Fatalf("invalid auth key for %s", spec)
+			}
+			backoff := spec.Backoff()
+			log.Warningf("manager: failed to renew certificate (err=%s), backing off for %0.0f seconds", err, backoff.Seconds())
+			metrics.FailureCount.WithLabelValues(spec.Path).Inc()
+			time.Sleep(backoff)
+			continue
+		}
+
+		spec.ResetBackoff()
+		return nil
+	}
+	stop := time.Now()
+
+	spec.ResetBackoff()
+	return fmt.Errorf("manager: failed to renew %s in %d attempts (in %0.0f seconds)", spec, maxAttempts, stop.Sub(start).Seconds())
+}
+
+// CheckCA checks the CA on the certificate and restarts the service
+// if needed.
+func (spec *Spec) CheckCA() error {
+	var err error
+	var changed bool
+	if changed, err = spec.CA.Refresh(); err != nil {
+		metrics.ActionFailure.WithLabelValues(spec.Path, "CA").Inc()
+		return err
+	} else if changed {
+		metrics.Expires.WithLabelValues(spec.Path, "ca").Set(float64(spec.CAExpireTime().Unix()))
+		log.Debug("taking action due to CA refresh")
+		err := spec.TakeAction("CA")
+
+		if err != nil {
+			metrics.ActionFailure.WithLabelValues(spec.Path, "CA").Inc()
+			log.Errorf("manager: %s", err)
+		}
+	}
+	metrics.Expires.WithLabelValues(spec.Path, "ca").Set(float64(spec.CAExpireTime().Unix()))
+	return err
 }

--- a/cert/spec.go
+++ b/cert/spec.go
@@ -170,19 +170,6 @@ func Load(path, remote string, before time.Duration, defaultServiceManager strin
 		return nil, errors.New("cert: no remote specified in authority (either in the spec or in the certmgr config)")
 	}
 
-	err = spec.Key.Parse("private_key")
-	if err != nil {
-		return nil, err
-	}
-
-	err = spec.Cert.Parse("certificate")
-	if err != nil {
-		return nil, err
-	}
-
-	spec.Key.Path = filepath.Clean(spec.Key.Path)
-	spec.Cert.Path = filepath.Clean(spec.Cert.Path)
-
 	err = spec.CA.Load()
 	if err != nil {
 		return nil, err

--- a/cert/spec.go
+++ b/cert/spec.go
@@ -84,7 +84,7 @@ func (spec *Spec) String() string {
 }
 
 // Identity creates a transport package identity for the certificate.
-func (spec *Spec) Identity() (*core.Identity, error) {
+func (spec *Spec) identity() (*core.Identity, error) {
 	ident := &core.Identity{
 		Request: spec.Request,
 		Roots: []*core.Root{
@@ -175,7 +175,7 @@ func Load(path, remote string, before time.Duration, defaultServiceManager strin
 		return nil, err
 	}
 
-	identity, err := spec.Identity()
+	identity, err := spec.identity()
 	if err != nil {
 		return nil, err
 	}

--- a/cert/spec.go
+++ b/cert/spec.go
@@ -320,13 +320,13 @@ func (spec *Spec) CheckDiskPKI() error {
 
 	if algDisk != algSpec {
 		metrics.AlgorithmMismatchCount.WithLabelValues(spec.Path).Set(1)
-		return fmt.Errorf("manager: disk alg is %s but spec alg is %s\n", algDisk, algSpec)
+		return fmt.Errorf("manager: disk alg is %s but spec alg is %s", algDisk, algSpec)
 	}
 	metrics.AlgorithmMismatchCount.WithLabelValues(spec.Path).Set(0)
 
 	if sizeDisk != sizeSpec {
 		metrics.KeysizeMismatchCount.WithLabelValues(spec.Path).Set(1)
-		return fmt.Errorf("manager: disk key size is %d but spec key size is %d\n", sizeDisk, sizeSpec)
+		return fmt.Errorf("manager: disk key size is %d but spec key size is %d", sizeDisk, sizeSpec)
 	}
 	metrics.KeysizeMismatchCount.WithLabelValues(spec.Path).Set(0)
 

--- a/cert/spec.go
+++ b/cert/spec.go
@@ -262,7 +262,7 @@ func (spec *Spec) Lifespan() time.Duration {
 	if spec.IsChangedOnDisk(spec.Key.Path) || spec.IsChangedOnDisk(spec.Cert.Path) {
 		// This is necessary to essentially force cfssl to regenerate since it's not spec aware.
 		log.Infof("refreshing due to spec %s having a newer mtime than key or cert", spec.Path)
-		spec.ResetLifespan()
+		spec.ForceRenewal()
 		return 0
 	}
 	return spec.tr.Lifespan()
@@ -400,8 +400,8 @@ func (spec *Spec) CAExpireTime() time.Time {
 	return parsedCert.NotAfter
 }
 
-// ResetLifespan Reset the lifespan to force cfssl to regenerate
-func (spec *Spec) ResetLifespan() {
+// ForceRenewal Reset the lifespan to force cfssl to regenerate
+func (spec *Spec) ForceRenewal() {
 	cert := spec.tr.Provider.Certificate()
 	if cert != nil {
 		spec.tr.Provider.Certificate().NotAfter = time.Time{}
@@ -436,7 +436,7 @@ func (spec *Spec) EnforcePKI(enableActions bool) (time.Duration, error) {
 	err := spec.CheckDiskPKI()
 	if err != nil {
 		log.Debugf("manager: %s, checkdiskpki: %s.  Forcing refresh.", spec, err.Error())
-		spec.ResetLifespan()
+		spec.ForceRenewal()
 	}
 
 	if err = spec.CheckCA(); err != nil {

--- a/cert/spec.go
+++ b/cert/spec.go
@@ -229,12 +229,12 @@ func (spec *Spec) RefreshKeys() error {
 		return err
 	}
 
-	err = spec.Key.Set()
+	err = spec.Key.setPermissions()
 	if err != nil {
 		return err
 	}
 
-	err = spec.Cert.Set()
+	err = spec.Cert.setPermissions()
 	if err != nil {
 		return err
 	}

--- a/cert/transport.go
+++ b/cert/transport.go
@@ -1,4 +1,4 @@
-package mgr
+package cert
 
 import (
 	"encoding/json"

--- a/cli/clean.go
+++ b/cli/clean.go
@@ -26,14 +26,14 @@ func clean(cmd *cobra.Command, args []string) {
 
 	var failed bool
 	for _, cert := range mgr.Certs {
-		err := cert.Key.Remove()
+		err := cert.Key.Unlink()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "certmgr: failed to remove the private key for %s (%s)\n",
 				cert, err)
 			failed = true
 		}
 
-		err = cert.Cert.Remove()
+		err = cert.Cert.Unlink()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "certmgr: failed to remove the certificate for %s (%s)\n",
 				cert, err)

--- a/cli/ensure.go
+++ b/cli/ensure.go
@@ -53,7 +53,7 @@ func ensure(cmd *cobra.Command, args []string) {
 			}
 			_, err = cert.EnforcePKI(enableActions)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Failed processing spec %s due to %s; %d remaining attempts", cert.Spec.Path, err, attempt)
+				fmt.Fprintf(os.Stderr, "Failed processing spec %s due to %s; %d remaining attempts", cert.Path, err, attempt)
 			} else {
 				break
 			}

--- a/cli/ensure.go
+++ b/cli/ensure.go
@@ -49,7 +49,7 @@ func ensure(cmd *cobra.Command, args []string) {
 	for _, cert := range mgr.Certs {
 		for attempt := ensureTolerance; attempt > 0; attempt-- {
 			if forceRegen {
-				cert.ResetLifespan()
+				cert.ForceRenewal()
 			}
 			_, err = cert.EnforcePKI(enableActions)
 			if err != nil {

--- a/cli/root.go
+++ b/cli/root.go
@@ -60,7 +60,7 @@ func root(cmd *cobra.Command, args []string) {
 	// so changes in certs count are properly reflected.
 	certs := []*cert.Spec{}
 	for _, x := range mgr.Certs {
-		certs = append(certs, x.Spec)
+		certs = append(certs, x)
 	}
 	metrics.Start(
 		viper.GetString("metrics_address"),


### PR DESCRIPTION
Core thrust here:
1) Drop CertServiceManager, move it into Spec.  This seperation forced exposing multiple internals that are ill designed/defined; dropping this 'wrapper' allows hiding more internals which allows refactoring and cleanup to happen without breaking API.
2) Via 1, privatize (and rename where sensical) spec methods to hide internals that shouldn't be public.
3) Move more of the parse logic down into File itself via using unmarshall methods; point there is to reduce the requirements of Spec to know to invoke specific methods as part of initialization; instead, just have initialization handle this.
4) Minor error message cleanup; removal of newlines.  More work will follow.
5) Add a link to the godocs since we're progressively getting closer to a usable API.