### PR TITLE
Metrics cleanup

### DIFF
--- a/cert/spec.go
+++ b/cert/spec.go
@@ -550,3 +550,18 @@ func (spec *Spec) updateCAExpiry(notAfter time.Time) {
 	spec.expiry.CA = notAfter
 	metrics.SpecExpires.WithLabelValues(spec.Path, "cert").Set(float64(notAfter.Unix()))
 }
+
+// WipeMetrics Wipes any metrics that may be recorded for this spec.
+// In general this should be invoked only when a spec is being removed from tracking.
+func (spec *Spec) WipeMetrics() {
+	metrics.SpecRefreshCount.DeleteLabelValues(spec.Path)
+	metrics.SpecCheckCount.DeleteLabelValues(spec.Path)
+	metrics.SpecWriteCount.DeleteLabelValues(spec.Path)
+	metrics.SpecWriteFailureCount.DeleteLabelValues(spec.Path)
+	metrics.SpecRequestFailureCount.DeleteLabelValues(spec.Path)
+	for _, t := range []string{"ca", "cert", "key"} {
+		metrics.SpecExpires.DeleteLabelValues(spec.Path, t)
+		metrics.ActionAttemptedCount.DeleteLabelValues(spec.Path, t)
+		metrics.ActionFailedCount.DeleteLabelValues(spec.Path, t)
+	}
+}

--- a/cert/spec.go
+++ b/cert/spec.go
@@ -548,7 +548,7 @@ func (spec *Spec) updateCertExpiry(notAfter time.Time) {
 }
 func (spec *Spec) updateCAExpiry(notAfter time.Time) {
 	spec.expiry.CA = notAfter
-	metrics.SpecExpires.WithLabelValues(spec.Path, "cert").Set(float64(notAfter.Unix()))
+	metrics.SpecExpires.WithLabelValues(spec.Path, "ca").Set(float64(notAfter.Unix()))
 }
 
 // WipeMetrics Wipes any metrics that may be recorded for this spec.

--- a/cert/spec.go
+++ b/cert/spec.go
@@ -214,6 +214,9 @@ func Load(path, remote string, before time.Duration, defaultServiceManager strin
 		}
 	}
 	spec.serviceManager = manager
+	if err == nil {
+		metrics.SpecExpiresBeforeThreshold.WithLabelValues(spec.Path).Set(float64(before.Seconds()))
+	}
 	return spec, err
 }
 
@@ -556,6 +559,7 @@ func (spec *Spec) updateCAExpiry(notAfter time.Time) {
 func (spec *Spec) WipeMetrics() {
 	metrics.SpecRefreshCount.DeleteLabelValues(spec.Path)
 	metrics.SpecCheckCount.DeleteLabelValues(spec.Path)
+	metrics.SpecExpiresBeforeThreshold.DeleteLabelValues(spec.Path)
 	metrics.SpecWriteCount.DeleteLabelValues(spec.Path)
 	metrics.SpecWriteFailureCount.DeleteLabelValues(spec.Path)
 	metrics.SpecRequestFailureCount.DeleteLabelValues(spec.Path)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -23,70 +23,97 @@ var (
 	SpecWatchCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: metricsNamespace,
-			Name:      "specs_watched_total",
+			Subsystem: "spec",
+			Name:      "watched_total",
 			Help:      "Number of specs being watched",
 		},
 		[]string{"spec_path", "svcmgr", "action", "ca"},
 	)
 
-	// Expires contains the time of the next certificate
+	// SpecRefreshCount counts the number of PKI regeneration taken by a spec
+	SpecRefreshCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: "spec",
+			Name:      "refresh_count",
+			Help:      "Number of times a spec has determined PKI must be refreshed",
+		},
+		[]string{"spec_path"},
+	)
+
+	// SpecCheckCount counts the number of PKI regeneration taken by a spec
+	SpecCheckCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: "spec",
+			Name:      "check_count",
+			Help:      "Number of times a spec PKI was checked",
+		},
+		[]string{"spec_path"},
+	)
+
+	// SpecLoadCount counts the number of times a spec was loaded from disk
+	SpecLoadCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: "spec",
+			Name:      "load_count",
+			Help:      "Number of times a spec was loaded from disk",
+		},
+		[]string{"spec_path"},
+	)
+
+	// SpecLoadFailureCount counts the number of times a spec couldn't be loaded from disk
+	SpecLoadFailureCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: "spec",
+			Name:      "load_failure_count",
+			Help:      "Number of times a spec was loaded from disk but failed to be parsed",
+		},
+		[]string{"spec_path"},
+	)
+	// SpecExpires contains the time of the next certificate
 	// expiry.
-	Expires = prometheus.NewGaugeVec(
+	SpecExpires = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: metricsNamespace,
-			Name:      "cert_expire_timestamp",
-			Help:      "The unix time for when the given spec and type expires",
+			Subsystem: "spec",
+			Name:      "expire_timestamp",
+			Help:      "The unix time for when the given spec and PKI type expires",
 		},
 		[]string{"spec_path", "type"},
 	)
 
-	// FailureCount contains a count of the number of failures to
-	// generate a key pair or renew a certificate.
-	FailureCount = prometheus.NewCounterVec(
+	// SpecWriteCount contains the number of times the PKI on disk was written
+	SpecWriteCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metricsNamespace,
-			Name:      "cert_renewal_failures",
-			Help:      "Number of keypair generation or cert renewal failures",
+			Subsystem: "spec",
+			Name:      "write_count",
+			Help:      "The number of times PKI on disk has been rewritten",
 		},
 		[]string{"spec_path"},
 	)
 
-	// AlgorithmMismatchCount counts mismatches occurred between algorithm on disk vs algorithm in spec
-	AlgorithmMismatchCount = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
+	// SpecWriteFailureCount contains the number of times the PKI on disk failed to be written
+	SpecWriteFailureCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
 			Namespace: metricsNamespace,
-			Name:      "algorithm_mismatch",
-			Help:      "Number of mismatches between cert algorithm on disk vs algorithm specified in spec",
+			Subsystem: "spec",
+			Name:      "write_failure_count",
+			Help:      "The number of times PKI on disk failed to be rewritten",
 		},
 		[]string{"spec_path"},
 	)
 
-	// KeysizeMismatchCount counts mismatches occurred between keysize on disk vs keysize in spec
-	KeysizeMismatchCount = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
+	// SpecRequestFailureCount counts the number of times a spec failed to request a certificate from upstream.
+	SpecRequestFailureCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
 			Namespace: metricsNamespace,
-			Name:      "keysize_mismatch",
-			Help:      "Number of mismatches between keysize disk vs keysize specified in spec",
-		},
-		[]string{"spec_path"},
-	)
-
-	// HostnameMismatchCount counts mismatches occurred between cert hostnames on disk vs cert hostnames in spec
-	HostnameMismatchCount = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: metricsNamespace,
-			Name:      "hostname_mismatch",
-			Help:      "Number of mismatches between cert hostnames on disk vs cert hostnames specified in spec",
-		},
-		[]string{"spec_path"},
-	)
-
-	// KeypairMismatchCount counts TLS mismatch between key and certificate on disk
-	KeypairMismatchCount = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: metricsNamespace,
-			Name:      "keypair_mismatch",
-			Help:      "Number of TLS mismatches between key and certificate on disk",
+			Subsystem: "spec",
+			Name:      "request_failure_count",
+			Help:      "Number of failed requests to CA authority for new PKI material",
 		},
 		[]string{"spec_path"},
 	)
@@ -101,22 +128,22 @@ var (
 		[]string{"directory"},
 	)
 
-	// ActionCount counts actions taken by spec
-	ActionCount = prometheus.NewCounterVec(
+	// ActionAttemptedCount counts actions taken by a spec
+	ActionAttemptedCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metricsNamespace,
-			Name:      "action_count",
+			Name:      "action_attempted_count",
 			Help:      "Number of times a spec has taken action",
 		},
 		[]string{"spec_path", "change_type"},
 	)
 
-	// ActionFailure counts number of times an action taken by spec failed
-	ActionFailure = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
+	// ActionFailedCount counts failed actions taken by a spec
+	ActionFailedCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
 			Namespace: metricsNamespace,
-			Name:      "action_failure",
-			Help:      "Number of times a spec's action has failed",
+			Name:      "action_failed_count",
+			Help:      "Number of failed action runs for a spec",
 		},
 		[]string{"spec_path", "change_type"},
 	)
@@ -126,15 +153,17 @@ func init() {
 	startTime = time.Now()
 
 	prometheus.MustRegister(SpecWatchCount)
-	prometheus.MustRegister(Expires)
-	prometheus.MustRegister(FailureCount)
-	prometheus.MustRegister(AlgorithmMismatchCount)
-	prometheus.MustRegister(KeysizeMismatchCount)
-	prometheus.MustRegister(HostnameMismatchCount)
-	prometheus.MustRegister(KeypairMismatchCount)
+	prometheus.MustRegister(SpecRefreshCount)
+	prometheus.MustRegister(SpecCheckCount)
+	prometheus.MustRegister(SpecLoadCount)
+	prometheus.MustRegister(SpecLoadFailureCount)
+	prometheus.MustRegister(SpecExpires)
+	prometheus.MustRegister(SpecWriteCount)
+	prometheus.MustRegister(SpecWriteFailureCount)
+	prometheus.MustRegister(SpecRequestFailureCount)
 	prometheus.MustRegister(ManagerInterval)
-	prometheus.MustRegister(ActionCount)
-	prometheus.MustRegister(ActionFailure)
+	prometheus.MustRegister(ActionAttemptedCount)
+	prometheus.MustRegister(ActionFailedCount)
 }
 
 var indexPage = `<html>

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -85,6 +85,18 @@ var (
 		[]string{"spec_path", "type"},
 	)
 
+	// SpecExpiresBeforeThreshold exports how much lead time we give for trying to renew a cert
+	// before it expires.
+	SpecExpiresBeforeThreshold = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Subsystem: "spec",
+			Name:      "expire_before_duration_seconds",
+			Help:      "When a spec is within this number of seconds of an expiry, renewal begins",
+		},
+		[]string{"spec_path"},
+	)
+
 	// SpecWriteCount contains the number of times the PKI on disk was written
 	SpecWriteCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -158,6 +170,7 @@ func init() {
 	prometheus.MustRegister(SpecLoadCount)
 	prometheus.MustRegister(SpecLoadFailureCount)
 	prometheus.MustRegister(SpecExpires)
+	prometheus.MustRegister(SpecExpiresBeforeThreshold)
 	prometheus.MustRegister(SpecWriteCount)
 	prometheus.MustRegister(SpecWriteFailureCount)
 	prometheus.MustRegister(SpecRequestFailureCount)

--- a/mgr/manager.go
+++ b/mgr/manager.go
@@ -117,10 +117,13 @@ var validExtensions = map[string]bool{
 
 func (m *Manager) loadSpec(path string, strict bool) (*cert.Spec, error) {
 	log.Infof("manager: loading spec from %s", path)
+	path = filepath.Clean(path)
+	metrics.SpecLoadCount.WithLabelValues(path).Inc()
 	spec, err := cert.Load(path, m.DefaultRemote, m.Before, m.ServiceManager, strict)
 	if err == nil {
 		log.Debugf("manager: successfully loaded spec from %s", path)
 	} else {
+		metrics.SpecLoadFailureCount.WithLabelValues(path).Inc()
 		log.Errorf("managed: failed loading spec from %s: %s", path, err)
 	}
 	return spec, err

--- a/mgr/manager.go
+++ b/mgr/manager.go
@@ -226,6 +226,8 @@ func (m *Manager) Server(strict bool) {
 					log.Errorf("failed to reload spec %s due to %s. Continuing to use old spec.", spec, err)
 					continue
 				}
+				// ensure we don't leave any stale metrics hanging around.
+				spec.WipeMetrics()
 				log.Infof("reloaded spec %s due to detected changes", spec)
 				m.Certs[idx] = newSpec
 			}


### PR DESCRIPTION
rough list of changes:
* Centralize action accounting into spec.TakeAction
* expose metrics tracking check/refresh counts.
* Refactor the metric names for spec to be subsystem prefixed with 'spec'.
* expose metrics for spec loading and failures to parse.
* expose metrics for PKI writes to disk, and failure counts.
* export metric count for *all* remote request failures, whether it be CA fetching
  or cert signing.
* Being we now can force regeneration for hostname/algo/key size
  changes, drop the metrics that track this.  If we need to track this
  level of granualarity, the logs have it- but now that we regenerate
  we don't need to surface this to prometheus.
* Wipe metrics on spec reload to prevent stale metrics.
* Fix updateCAExpiry to set the correct metric label value
* export a metric per spec for the 'before' threshold that is internally used.