### PR TITLE
Tighten validation, fix Spec.String() to be usable, and add support for writing just the CA

### DIFF
--- a/cert/spec.go
+++ b/cert/spec.go
@@ -79,19 +79,7 @@ type Spec struct {
 }
 
 func (spec *Spec) String() string {
-	extra := displayName(spec.Request.Name())
-	if extra == "" {
-		extra = spec.Service
-	}
-
-	if extra == "" {
-		extra = spec.Cert.Path
-	}
-	if extra != "" {
-		return fmt.Sprintf("%s: %s", spec.Cert.Path, extra)
-	}
-
-	return spec.Cert.Path
+	return spec.Path
 }
 
 // Identity creates a transport package identity for the certificate.

--- a/cert/spec.go
+++ b/cert/spec.go
@@ -5,7 +5,6 @@ package cert
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -159,7 +158,7 @@ func newSpecFromPath(path string) (*Spec, error) {
 
 	switch filepath.Ext(path) {
 	case ".json":
-		err = json.Unmarshal(in, &spec)
+		err = strictJSONUnmarshal(in, &spec)
 	case ".yml", ".yaml":
 		err = yaml.UnmarshalStrict(in, &spec)
 	default:

--- a/cert/util.go
+++ b/cert/util.go
@@ -3,10 +3,12 @@
 package cert
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -104,4 +106,19 @@ func encodeCertificateToPEM(cert *x509.Certificate) []byte {
 			Bytes: cert.Raw,
 		},
 	)
+}
+
+// strictJSONUnmarshal unmarshals a byte source into the given interface while also
+// enforcing that there is no unknown fields
+func strictJSONUnmarshal(data []byte, object interface{}) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	err := dec.Decode(object)
+	if err != nil {
+		return err
+	}
+	if dec.More() {
+		return errors.New("multiple json objects found, only one is allowed")
+	}
+	return nil
 }


### PR DESCRIPTION
Per the subject:
* this tightens the json checks to ensure there aren't any fields defined we don't know how to 'load'.
* in doing so, we also add support for writing just the CA to disk should the invoker want to be notified only of that.
* Via that cleanup, drop the spec.*Backoff methods since they are for manipulating the transport, and that's only needed (and handled) via a single internal method.
* Finally, the Spec.String() was gutted (and the path return fixed) to just be the spec path.  The extra output was not making loglines sane to work with or parse.

To support the CA/validation change, there has been more code shifted around trying to get closer to broken single purpose functions.  The naming likely needs some work, and the ordering of function definitions *definitely* needs cleanup, but that's follow up work.