### PR TITLE
Reject broken servicemanager definitions in specs

### DIFF
--- a/cli/check.go
+++ b/cli/check.go
@@ -21,11 +21,8 @@ func check(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatalf("Failed: %s", err)
 	}
-	strict, err := cmd.Flags().GetBool("strict")
-	if err != nil {
-		strict = false
-	}
-	err = mgr.Load(false, strict)
+
+	err = mgr.Load()
 	if err != nil {
 		log.Fatalf("Failed: %s", err)
 	}

--- a/cli/clean.go
+++ b/cli/clean.go
@@ -13,11 +13,7 @@ func clean(cmd *cobra.Command, args []string) {
 		log.Fatalf("Failed: %s", err)
 	}
 
-	strict, err := cmd.Flags().GetBool("strict")
-	if err != nil {
-		strict = false
-	}
-	err = mgr.Load(false, strict)
+	err = mgr.Load()
 	if err != nil {
 		log.Fatalf("failed: %s", err)
 	}

--- a/cli/ensure.go
+++ b/cli/ensure.go
@@ -26,11 +26,7 @@ func ensure(cmd *cobra.Command, args []string) {
 		log.Fatalf("failed creating manager", err)
 	}
 
-	strict, err := cmd.Flags().GetBool("strict")
-	if err != nil {
-		strict = false
-	}
-	err = mgr.Load(false, strict)
+	err = mgr.Load()
 	if err != nil {
 		log.Fatalf("failed loading manager: %s", err)
 	}

--- a/cli/root.go
+++ b/cli/root.go
@@ -22,7 +22,6 @@ import (
 var cfgFile string
 var logLevel string
 var jsonLogging bool
-var strict bool
 var requireSpecs bool
 
 var manager struct {
@@ -47,11 +46,8 @@ func root(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatalf("certmgr: %s", err)
 	}
-	strict, err := cmd.Flags().GetBool("strict")
-	if err != nil {
-		strict = false
-	}
-	err = mgr.Load(false, strict)
+
+	err = mgr.Load()
 	if err != nil {
 		log.Fatalf("certmgr: %s", err)
 	}
@@ -70,7 +66,7 @@ func root(cmd *cobra.Command, args []string) {
 		viper.GetString("metrics_address"),
 		viper.GetString("metrics_port"),
 	)
-	mgr.Server(strict)
+	mgr.Server()
 }
 
 // RootCmd this is our command processor for CLI interactions
@@ -104,7 +100,6 @@ func init() {
 	RootCmd.PersistentFlags().DurationVarP(&manager.Interval, "interval", "i", mgr.DefaultInterval, "how long to sleep before checking for renewal (in duration format)")
 	RootCmd.PersistentFlags().BoolVarP(&jsonLogging, "log.json", "", false, "if passed, logging will be in json")
 	RootCmd.PersistentFlags().StringVarP(&logLevel, "log.level", "l", "info", "logging level.  Must be one [debug|info|warning|error]")
-	RootCmd.PersistentFlags().BoolVar(&strict, "strict", false, "refuse to load certificate without valid renewal action defined")
 	RootCmd.Flags().BoolVarP(&requireSpecs, "requireSpecs", "", false, "fail the daemon startup if no specs were found in the directory to watch")
 
 	viper.BindPFlag("dir", RootCmd.PersistentFlags().Lookup("dir"))

--- a/svcmgr/svcmgr.go
+++ b/svcmgr/svcmgr.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -54,6 +55,9 @@ func New(name string, action string, service string) (Manager, error) {
 	}
 
 	manager, err := smFunc(action, service)
+	if err != nil && action == "" && service == "" {
+		return nil, errors.WithMessage(err, "failed to instantiate due to empty action/service; perhaps you meant to use the 'dummy' service manager?")
+	}
 	return manager, err
 }
 


### PR DESCRIPTION
If a spec explicitly defines action, service, or `svcmgr`, then the spec is trying to configure a notification mechanism.

This PR changes logic such that it's mandatory that this parse; if it cannot, then the spec is rejected and code above behaves accordingly (fails namely).

If no field is defined, then we treat the spec as 'dummy'- albeit logging a warning that there is no notification mechanism configured.