### PR TITLE
release 2.0.0

### DIFF
--- a/cert/spec.go
+++ b/cert/spec.go
@@ -372,15 +372,16 @@ func (spec *Spec) EnforcePKI(enableActions bool) error {
 
 	metrics.SpecCheckCount.WithLabelValues(spec.Path).Inc()
 
+	currentCA, err = spec.CA.getRemoteCert()
+	if err != nil {
+		metrics.SpecRequestFailureCount.WithLabelValues(spec.Path).Inc()
+		return errors.WithMessage(err, "failed getting remote")
+	}
+
 	if spec.renewalForced {
 		updateReason = "key"
 		err = errors.New("regeneration was forced")
 	} else {
-		currentCA, err = spec.CA.getRemoteCert()
-		if err != nil {
-			metrics.SpecRequestFailureCount.WithLabelValues(spec.Path).Inc()
-			return errors.WithMessage(err, "failed getting remote")
-		}
 
 		if spec.CA.File != nil {
 			var existingCA *x509.Certificate

--- a/cli/version.go
+++ b/cli/version.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-var currentVersion = "2.0.0-rc0"
+var currentVersion = "2.0.0"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",


### PR DESCRIPTION
This fixes a regression in `certmgr ensure --forceRegen --enableActions`, and marks the 2.0.0 release.