### PR TITLE
Add permission checks, ensure mgr paths are unique, and release 2.0.1

### DIFF
--- a/cert/cert_test.go
+++ b/cert/cert_test.go
@@ -1,0 +1,36 @@
+package cert
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestSpecPaths(t *testing.T) {
+	spec := Spec{}
+	assert := func(desired, received []string) {
+		sort.Strings(desired)
+		sort.Strings(received)
+
+		if len(received) != len(desired) {
+			t.Fatalf("%s != %s", desired, received)
+		}
+		for idx := range received {
+			if desired[idx] != received[idx] {
+				t.Fatalf("%s != %s", desired, received)
+			}
+		}
+	}
+
+	// ensure that an empty spec doesn't trigger a panic
+	assert([]string{}, spec.Paths())
+	spec.CA.File = &CertificateFile{File{Path: "/ca"}}
+
+	assert([]string{"/ca"}, spec.Paths())
+	spec.Cert = &CertificateFile{File{Path: "/cert"}}
+	spec.Key = &File{Path: "/key"}
+
+	assert([]string{"/ca", "/key", "/cert"}, spec.Paths())
+
+	spec.CA.File = nil
+	assert([]string{"/key", "/cert"}, spec.Paths())
+}

--- a/cli/version.go
+++ b/cli/version.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-var currentVersion = "2.0.0"
+var currentVersion = "2.0.1"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",


### PR DESCRIPTION
Core points:
* the PKI pathways a spec refers to need to be unique.  It's not sensical for 2 specs to try managing the same content- thus detect this and treat it as an error.  In the best case, certmgr would just trigger redundant notifications- in the common case, the PKI/specs differ leading to inconsistencies at best.
* Detect if permissions have changed on disk for PKI content, and force a regeneration if this has occurred.  Certmgr has no way of knowing if the OOB change to the permissions prevented the service from accessing the PKI- thus our only option is to trigger a regen.

  Note that this can be tightened at a later date so it triggers a regen only if an action is configured... but this is a questionable optimization.  Very few services can detect (safely) PKI changing on disk and auto-reload; they are the minority.  It's better to trigger the regen in this scenario for supporting the majority.

Finally, release 2.0.1 with these changes, and the previous fix for host comparison when IP addresses are involved.