### PR TITLE
Refactor spec/mgr to move monitoring/sleeping to spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ A certificate spec has the following fields:
 * `private_key` and `certificate`: file specifications (see below) for
   the private key and certificate.  Both must be specified- as must `request`- if you wish to manage a certificate/key pair.
 * `authority`: contains the CFSSL CA configuration (see below).
+* `before`: optional, this is a time.Duration of how early to pre-emptively renew a certificate before it's expiry.
+   If unspecified, then the manager's default is used instead (and if that is unspecified, it defaults to 72h).
+* `interval`: optional, this is the time.Duration of how long to sleep for before checking a spec's on disk PKI and CA to see
+   if anything has changed.  If unspecified, the manager default is used (and if that is unspecified, it defaults to an hour).
 
 **Note**: `certmgr` will throw a warning if `svcmgr` is `dummy` _AND_ `action` is "nop" or undefined. This is because such a setup will not properly restart or reload a service upon certiifcate renewal, which will likely cause your service to crash. Running `certmgr` with the `--strict` flag will not even load a certificate spec with a `dummy svcmgr` and undefined/nop `action` configuration.
 

--- a/cli/root.go
+++ b/cli/root.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/cloudflare/certmgr/cert"
 	"github.com/cloudflare/certmgr/metrics"
 	"github.com/cloudflare/certmgr/mgr"
 	"github.com/cloudflare/certmgr/svcmgr"
@@ -37,10 +38,12 @@ var manager struct {
 func newManager() (*mgr.Manager, error) {
 	return mgr.New(
 		viper.GetString("dir"),
-		viper.GetString("default_remote"),
-		viper.GetString("svcmgr"),
-		viper.GetDuration("before"),
-		viper.GetDuration("interval"),
+		&cert.SpecOptions{
+			Remote:             viper.GetString("default_remote"),
+			ServiceManagerName: viper.GetString("svcmgr"),
+			Before:             viper.GetDuration("before"),
+			Interval:           viper.GetDuration("interval"),
+		},
 	)
 }
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -9,9 +9,9 @@ import (
 	_ "net/http/pprof" // start a pprof endpoint
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	log "github.com/sirupsen/logrus"
 )
 
 const metricsNamespace = "certmgr"
@@ -130,14 +130,15 @@ var (
 		[]string{"spec_path"},
 	)
 
-	// ManagerInterval is set to the interval at which a cert manager wakes up and does its checks
-	ManagerInterval = prometheus.NewGaugeVec(
+	// SpecInterval is set to the interval at which a cert manager wakes up and does its checks
+	SpecInterval = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: metricsNamespace,
-			Name:      "manager_interval_seconds",
-			Help:      "the time interval that manager wakes up and does checks",
+			Subsystem: "spec",
+			Name:      "interval_seconds",
+			Help:      "the time interval that this spec will sleep for between checks",
 		},
-		[]string{"directory"},
+		[]string{"spec_path"},
 	)
 
 	// ActionAttemptedCount counts actions taken by a spec
@@ -174,7 +175,7 @@ func init() {
 	prometheus.MustRegister(SpecWriteCount)
 	prometheus.MustRegister(SpecWriteFailureCount)
 	prometheus.MustRegister(SpecRequestFailureCount)
-	prometheus.MustRegister(ManagerInterval)
+	prometheus.MustRegister(SpecInterval)
 	prometheus.MustRegister(ActionAttemptedCount)
 	prometheus.MustRegister(ActionFailedCount)
 }

--- a/util/types.go
+++ b/util/types.go
@@ -1,0 +1,25 @@
+package util
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// ParsableDuration is a custom type to provide time.Duration unmarshalling.
+type ParsableDuration time.Duration
+
+// UnmarshalJSON unmarshall's a JSON string into a time.Duration
+func (d *ParsableDuration) UnmarshalJSON(data []byte) error {
+	// note: yaml.v3 won't support ints, so neither will we.
+	var err error
+	var val string
+	if err = json.Unmarshal(data, &val); err != nil {
+		return err
+	}
+	temp, err := time.ParseDuration(val)
+	if err != nil {
+		*d = (ParsableDuration)(temp)
+	}
+
+	return err
+}

--- a/vendor/github.com/sirupsen/logrus/go.mod
+++ b/vendor/github.com/sirupsen/logrus/go.mod
@@ -8,3 +8,5 @@ require (
 	github.com/stretchr/testify v1.2.2
 	golang.org/x/sys v0.0.0-20190422165155-953cdadca894
 )
+
+go 1.13

--- a/vendor/github.com/spf13/viper/go.mod
+++ b/vendor/github.com/spf13/viper/go.mod
@@ -41,3 +41,5 @@ require (
 	google.golang.org/grpc v1.21.0 // indirect
 	gopkg.in/yaml.v2 v2.2.2
 )
+
+go 1.13


### PR DESCRIPTION
In the process, this adds support for `Begin` and `Interval` to spec's.  It also restructures the flow to make it so that new spec options- splay for example- can be added at the spec level and/or inherited from the manager level.  That's the intended end goal.

To get there, the 'control' had to be flipped from the manager (which should just be a dumb collector/holder of specs) to the specs for execution- this was accomplished via integrating context usage in.  In doing so, proper reload support was added and opportunistic reload was removed- certmgr no longer tries to reload spec's unless it's explicitly told to do so.  The upshot of this however is that certmgr now no longer requires a restart to reload all spec's- it's now able to do so.

That's a brief summary; see the commit messages for full details of each.

This PR primarily just restructures things for feature additions that will follow, while also realigning encapsulation so I can bury more internal details.  Followup work will be thus:

* Addition of splay logic; that'll be simple enough.
* Optional rewrite mgr's parsing logic of /etc/certmgr/certmgr.yaml to actually use yaml instead of viper's internals; in the process, this will add actual errors if configurables are specified and unknown.
* Optional control socket.  This is primarily useful for salt interactions and for proper reload invocations by systemctl (the `certmgr reload` could return nonzero exit if the running instance detected config issues for reload).
* Mostly non-optional: refactor spec api enough that arbitrary client libraries can pass a notification callback in for when content changes.  The main pathways should be refactored to use the same- in doing so, this will also allow for defering the 'store' step to the invoker (for example, to put the keys/certs in an environment of a process).
* Optional and as a follow on- and I strongly mean *optional*- implementation of `certmgr run --spec <spec> binary <args>`.   If this is an hour to implement, I'll do so, if not, I'll leave it as an exercise for others.