### PR TITLE
Implement splay logic for spec wakeup and renewal.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,17 @@ This contains all of the currently available parameters:
   `sysv` (using `service`), `circus` (using `circusctl`), `openrc` (using `rc-service`),
   `dummy` (no restart/reload behavior), or `command` (see the command svcmgr section
   for details of how to use this).
-* `before`: this is the interval before a certificate expires to start
-  attempting to renew it.
-* `interval`: this controls how often `certmgr` will check certificate expirations
-  and update PKI material on disk upon any changes (if necessary).
+* `before`: optional: this is the default duration before a certificate expiry that certmgr starts attempting to
+  renew PKI.  This defaults to 72 hours.
+* `interval`: optional: this is the default for how often `certmgr` will check certificate expirations
+  and update PKI material on disk upon any changes (if necessary).  This defaults to one hour.
+* `interval_splay`: optional: this is used to vary the interval period.  A random time between 0
+  and this value is added to `interval` if specified.  This defaults to 0.
+* `initial_splay`: if specified, a random sleep period between 0 and this value is used
+  for the initial sleep after startup of a spec.  This provides a way to ensure that
+  if a fleet of certmgr are restarted at the same time, their period of wakeup is randomized
+  to avoid said fleet waking up and doing interval checks at the same time for a given spec.
+  This defaults to 0.
 * `metrics_address`: specifies the address for the Prometheus HTTP
   endpoint.
 * `metrics_port`: specifies the port for the Prometheus HTTP endpoint.
@@ -164,10 +171,20 @@ A certificate spec has the following fields:
 * `private_key` and `certificate`: file specifications (see below) for
   the private key and certificate.  Both must be specified- as must `request`- if you wish to manage a certificate/key pair.
 * `authority`: contains the CFSSL CA configuration (see below).
-* `before`: optional, this is a time.Duration of how early to pre-emptively renew a certificate before it's expiry.
-   If unspecified, then the manager's default is used instead (and if that is unspecified, it defaults to 72h).
-* `interval`: optional, this is the time.Duration of how long to sleep for before checking a spec's on disk PKI and CA to see
-   if anything has changed.  If unspecified, the manager default is used (and if that is unspecified, it defaults to an hour).
+* `before`: optional: this is the default duration before a certificate expiry that certmgr starts attempting to
+  renew PKI.  This defaults to the managers default, which defaults to 72 hours if unspecified.
+* `interval`: optional: this is the default for how often `certmgr` will check certificate expirations
+  and update PKI material on disk upon any changes (if necessary).  This defaults to the managers default, which
+  defaults to one hour if unspecified.
+* `interval_splay`: optional: this is used to vary the interval period.  A random time between 0
+  and this value is added to `interval` if specified.  This defaults to the managers default, which defaults to 0
+  if unspecified.
+* `initial_splay`: if specified, a random sleep period between 0 and this value is used
+  for the initial sleep after startup of a spec.  This provides a way to ensure that
+  if a fleet of certmgr are restarted at the same time, their period of wakeup is randomized
+  to avoid said fleet waking up and doing interval checks at the same time for a given spec.
+  This defaults to the managers default, which defaults to 0 if unspecified.
+
 
 **Note**: `certmgr` will throw a warning if `svcmgr` is `dummy` _AND_ `action` is "nop" or undefined. This is because such a setup will not properly restart or reload a service upon certiifcate renewal, which will likely cause your service to crash. Running `certmgr` with the `--strict` flag will not even load a certificate spec with a `dummy svcmgr` and undefined/nop `action` configuration.
 

--- a/cli/root.go
+++ b/cli/root.go
@@ -33,6 +33,8 @@ var manager struct {
 	ServiceManager string
 	Before         time.Duration
 	Interval       time.Duration
+	IntervalSplay  time.Duration
+	InitialSplay   time.Duration
 }
 
 func newManager() (*mgr.Manager, error) {
@@ -43,6 +45,8 @@ func newManager() (*mgr.Manager, error) {
 			ServiceManagerName: viper.GetString("svcmgr"),
 			Before:             viper.GetDuration("before"),
 			Interval:           viper.GetDuration("interval"),
+			IntervalSplay:      viper.GetDuration("interval.splay"),
+			InitialSplay:       viper.GetDuration("initial.splay"),
 		},
 	)
 }
@@ -147,6 +151,8 @@ func init() {
 	RootCmd.PersistentFlags().StringVarP(&manager.ServiceManager, "svcmgr", "m", "", fmt.Sprintf("service manager, must be one of: %s", strings.Join(backends, ", ")))
 	RootCmd.PersistentFlags().DurationVarP(&manager.Before, "before", "t", mgr.DefaultBefore, "how long before certificates expire to start renewing (in duration format)")
 	RootCmd.PersistentFlags().DurationVarP(&manager.Interval, "interval", "i", mgr.DefaultInterval, "how long to sleep before checking for renewal (in duration format)")
+	RootCmd.PersistentFlags().DurationVarP(&manager.IntervalSplay, "interval.splay", "", 0*time.Second, "a rng value of [0..interval.splay] to add to each interval to randomize wake time")
+	RootCmd.PersistentFlags().DurationVarP(&manager.InitialSplay, "initial.splay", "", 0*time.Second, "if specified, this is a rng value of [0..initial.splay] used to randomize the first wake period.  Subsequence wakes use interval configurables.")
 	RootCmd.PersistentFlags().BoolVarP(&jsonLogging, "log.json", "", false, "if passed, logging will be in json")
 	RootCmd.PersistentFlags().StringVarP(&logLevel, "log.level", "l", "info", "logging level.  Must be one [debug|info|warning|error]")
 	RootCmd.Flags().BoolVarP(&requireSpecs, "requireSpecs", "", false, "fail the daemon startup if no specs were found in the directory to watch")
@@ -155,6 +161,8 @@ func init() {
 	viper.BindPFlag("svcmgr", RootCmd.PersistentFlags().Lookup("svcmgr"))
 	viper.BindPFlag("before", RootCmd.PersistentFlags().Lookup("before"))
 	viper.BindPFlag("interval", RootCmd.PersistentFlags().Lookup("interval"))
+	viper.BindPFlag("interval.splay", RootCmd.PersistentFlags().Lookup("interval.splay"))
+	viper.BindPFlag("initial.splay", RootCmd.PersistentFlags().Lookup("initial.splay"))
 }
 
 // initConfig reads in config file and ENV variables if set.


### PR DESCRIPTION
Two core configurables are added:

initial_splay:

This is the max time duration to sleep after the first enforcement on startup-
a random sleep between 0 and this value will be enforced to 'splay' certmgr
instances, to randomize their startup.  This is primarily needed for when
you don't want 100's of certmgr instances (all which started at the same time)
doing interval checks at the same time- this can be used to randomize the start.

interval_splay:

A random value between 0 and this value is added to the interval (after initial_splay
has been used) to splay the wakeup of running instances.  This is useful for jittering
long running certmgr instances wake up interval's, but understand that by definition
things will average around the half of this value across a long enough time range
(a proper RNG will result in an average of half across enough data); think of this
as jitter for running instances, the value operators should most be interested in
is initial_splay to provide the initial 'splay' of wakeups.  This just provides
another way to splay the load if folks want more than what initial_splay provides.