### PR TITLE
Metrics cleanup

### DIFF
--- a/cert/metrics.go
+++ b/cert/metrics.go
@@ -97,13 +97,13 @@ var (
 		[]string{"spec_path"},
 	)
 
-	// SpecInterval is set to the interval at which a cert manager wakes up and does its checks
-	SpecInterval = prometheus.NewGaugeVec(
+	// SpecNextWake is set to the timestamp of the next wakeup to check and enforce a spec.
+	SpecNextWake = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: metricsNamespace,
 			Subsystem: "spec",
-			Name:      "interval_seconds",
-			Help:      "the time interval that this spec will sleep for between checks",
+			Name:      "spec_next_wake_timestamp",
+			Help:      "The epoch value of when this spec will next awaken to perform checks",
 		},
 		[]string{"spec_path"},
 	)
@@ -138,7 +138,7 @@ func init() {
 	prometheus.MustRegister(SpecWriteCount)
 	prometheus.MustRegister(SpecWriteFailureCount)
 	prometheus.MustRegister(SpecRequestFailureCount)
-	prometheus.MustRegister(SpecInterval)
+	prometheus.MustRegister(SpecNextWake)
 	prometheus.MustRegister(ActionAttemptedCount)
 	prometheus.MustRegister(ActionFailedCount)
 }
@@ -149,7 +149,7 @@ func (spec *Spec) WipeMetrics() {
 	SpecRefreshCount.DeleteLabelValues(spec.Path)
 	SpecCheckCount.DeleteLabelValues(spec.Path)
 	SpecExpiresBeforeThreshold.DeleteLabelValues(spec.Path)
-	SpecInterval.DeleteLabelValues(spec.Path)
+	SpecNextWake.DeleteLabelValues(spec.Path)
 	SpecWriteCount.DeleteLabelValues(spec.Path)
 	SpecWriteFailureCount.DeleteLabelValues(spec.Path)
 	SpecRequestFailureCount.DeleteLabelValues(spec.Path)

--- a/cert/metrics.go
+++ b/cert/metrics.go
@@ -1,0 +1,161 @@
+package cert
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const metricsNamespace = "certmgr"
+
+var (
+	// SpecWatchCount counts the number of specs being watched.
+	SpecWatchCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Subsystem: "spec",
+			Name:      "watched_total",
+			Help:      "Number of specs being watched",
+		},
+		[]string{"spec_path", "svcmgr", "action", "ca"},
+	)
+
+	// SpecRefreshCount counts the number of PKI regeneration taken by a spec
+	SpecRefreshCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: "spec",
+			Name:      "refresh_count",
+			Help:      "Number of times a spec has determined PKI must be refreshed",
+		},
+		[]string{"spec_path"},
+	)
+
+	// SpecCheckCount counts the number of PKI regeneration taken by a spec
+	SpecCheckCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: "spec",
+			Name:      "check_count",
+			Help:      "Number of times a spec PKI was checked",
+		},
+		[]string{"spec_path"},
+	)
+
+	// SpecExpires contains the time of the next certificate
+	// expiry.
+	SpecExpires = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Subsystem: "spec",
+			Name:      "expire_timestamp",
+			Help:      "The unix time for when the given spec and PKI type expires",
+		},
+		[]string{"spec_path", "type"},
+	)
+
+	// SpecExpiresBeforeThreshold exports how much lead time we give for trying to renew a cert
+	// before it expires.
+	SpecExpiresBeforeThreshold = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Subsystem: "spec",
+			Name:      "expire_before_duration_seconds",
+			Help:      "When a spec is within this number of seconds of an expiry, renewal begins",
+		},
+		[]string{"spec_path"},
+	)
+
+	// SpecWriteCount contains the number of times the PKI on disk was written
+	SpecWriteCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: "spec",
+			Name:      "write_count",
+			Help:      "The number of times PKI on disk has been rewritten",
+		},
+		[]string{"spec_path"},
+	)
+
+	// SpecWriteFailureCount contains the number of times the PKI on disk failed to be written
+	SpecWriteFailureCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: "spec",
+			Name:      "write_failure_count",
+			Help:      "The number of times PKI on disk failed to be rewritten",
+		},
+		[]string{"spec_path"},
+	)
+
+	// SpecRequestFailureCount counts the number of times a spec failed to request a certificate from upstream.
+	SpecRequestFailureCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: "spec",
+			Name:      "request_failure_count",
+			Help:      "Number of failed requests to CA authority for new PKI material",
+		},
+		[]string{"spec_path"},
+	)
+
+	// SpecInterval is set to the interval at which a cert manager wakes up and does its checks
+	SpecInterval = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Subsystem: "spec",
+			Name:      "interval_seconds",
+			Help:      "the time interval that this spec will sleep for between checks",
+		},
+		[]string{"spec_path"},
+	)
+
+	// ActionAttemptedCount counts actions taken by a spec
+	ActionAttemptedCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "action_attempted_count",
+			Help:      "Number of times a spec has taken action",
+		},
+		[]string{"spec_path", "change_type"},
+	)
+
+	// ActionFailedCount counts failed actions taken by a spec
+	ActionFailedCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Name:      "action_failed_count",
+			Help:      "Number of failed action runs for a spec",
+		},
+		[]string{"spec_path", "change_type"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(SpecWatchCount)
+	prometheus.MustRegister(SpecRefreshCount)
+	prometheus.MustRegister(SpecCheckCount)
+	prometheus.MustRegister(SpecExpires)
+	prometheus.MustRegister(SpecExpiresBeforeThreshold)
+	prometheus.MustRegister(SpecWriteCount)
+	prometheus.MustRegister(SpecWriteFailureCount)
+	prometheus.MustRegister(SpecRequestFailureCount)
+	prometheus.MustRegister(SpecInterval)
+	prometheus.MustRegister(ActionAttemptedCount)
+	prometheus.MustRegister(ActionFailedCount)
+}
+
+// WipeMetrics Wipes any metrics that may be recorded for this spec.
+// In general this should be invoked only when a spec is being removed from tracking.
+func (spec *Spec) WipeMetrics() {
+	SpecRefreshCount.DeleteLabelValues(spec.Path)
+	SpecCheckCount.DeleteLabelValues(spec.Path)
+	SpecExpiresBeforeThreshold.DeleteLabelValues(spec.Path)
+	SpecInterval.DeleteLabelValues(spec.Path)
+	SpecWriteCount.DeleteLabelValues(spec.Path)
+	SpecWriteFailureCount.DeleteLabelValues(spec.Path)
+	SpecRequestFailureCount.DeleteLabelValues(spec.Path)
+	for _, t := range []string{"ca", "cert", "key"} {
+		SpecExpires.DeleteLabelValues(spec.Path, t)
+		ActionAttemptedCount.DeleteLabelValues(spec.Path, t)
+		ActionFailedCount.DeleteLabelValues(spec.Path, t)
+	}
+}

--- a/cert/metrics.go
+++ b/cert/metrics.go
@@ -7,17 +7,6 @@ import (
 const metricsNamespace = "certmgr"
 
 var (
-	// SpecWatchCount counts the number of specs being watched.
-	SpecWatchCount = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: metricsNamespace,
-			Subsystem: "spec",
-			Name:      "watched_total",
-			Help:      "Number of specs being watched",
-		},
-		[]string{"spec_path", "svcmgr", "action", "ca"},
-	)
-
 	// SpecRefreshCount counts the number of PKI regeneration taken by a spec
 	SpecRefreshCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -130,7 +119,6 @@ var (
 )
 
 func init() {
-	prometheus.MustRegister(SpecWatchCount)
 	prometheus.MustRegister(SpecRefreshCount)
 	prometheus.MustRegister(SpecCheckCount)
 	prometheus.MustRegister(SpecExpires)

--- a/cert/spec.go
+++ b/cert/spec.go
@@ -669,6 +669,7 @@ func (spec *Spec) updateCertExpiry(notAfter time.Time) {
 	spec.expiry.Cert = notAfter
 	SpecExpires.WithLabelValues(spec.Path, "cert").Set(float64(notAfter.Unix()))
 }
+
 func (spec *Spec) updateCAExpiry(notAfter time.Time) {
 	spec.expiry.CA = notAfter
 	SpecExpires.WithLabelValues(spec.Path, "ca").Set(float64(notAfter.Unix()))
@@ -696,7 +697,7 @@ func (spec *Spec) Run(ctx context.Context) {
 	}
 	for {
 		log.Infof("spec %s: Next check will be in %s", spec, sleepPeriod)
-		SpecInterval.WithLabelValues(spec.Path).Set(float64(sleepPeriod.Seconds()))
+		SpecNextWake.WithLabelValues(spec.Path).Set(float64(time.Now().Add(sleepPeriod).Unix()))
 		select {
 		case <-time.After(sleepPeriod):
 			log.Debugf("spec %s: woke, starting enforcement", spec)

--- a/cert/spec.go
+++ b/cert/spec.go
@@ -679,7 +679,6 @@ func (spec *Spec) updateCAExpiry(notAfter time.Time) {
 func (spec *Spec) Run(ctx context.Context) {
 	// initialize our run   At this point an observer knows this spec is 'alive' and being enforced.
 	SpecExpiresBeforeThreshold.WithLabelValues(spec.Path).Set(float64(spec.Before.Seconds()))
-	SpecWatchCount.WithLabelValues(spec.Path, spec.ServiceManagerName, spec.Action, spec.CA.Label).Inc()
 
 	// cleanup our runtime metrics on the way out so the observer knows we're no longer enforcing.
 	defer spec.WipeMetrics()

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -9,7 +9,6 @@ import (
 	_ "net/http/pprof" // start a pprof endpoint
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 )
@@ -18,166 +17,10 @@ const metricsNamespace = "certmgr"
 
 var (
 	startTime time.Time
-
-	// SpecWatchCount counts the number of specs being watched.
-	SpecWatchCount = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: metricsNamespace,
-			Subsystem: "spec",
-			Name:      "watched_total",
-			Help:      "Number of specs being watched",
-		},
-		[]string{"spec_path", "svcmgr", "action", "ca"},
-	)
-
-	// SpecRefreshCount counts the number of PKI regeneration taken by a spec
-	SpecRefreshCount = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: metricsNamespace,
-			Subsystem: "spec",
-			Name:      "refresh_count",
-			Help:      "Number of times a spec has determined PKI must be refreshed",
-		},
-		[]string{"spec_path"},
-	)
-
-	// SpecCheckCount counts the number of PKI regeneration taken by a spec
-	SpecCheckCount = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: metricsNamespace,
-			Subsystem: "spec",
-			Name:      "check_count",
-			Help:      "Number of times a spec PKI was checked",
-		},
-		[]string{"spec_path"},
-	)
-
-	// SpecLoadCount counts the number of times a spec was loaded from disk
-	SpecLoadCount = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: metricsNamespace,
-			Subsystem: "spec",
-			Name:      "load_count",
-			Help:      "Number of times a spec was loaded from disk",
-		},
-		[]string{"spec_path"},
-	)
-
-	// SpecLoadFailureCount counts the number of times a spec couldn't be loaded from disk
-	SpecLoadFailureCount = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: metricsNamespace,
-			Subsystem: "spec",
-			Name:      "load_failure_count",
-			Help:      "Number of times a spec was loaded from disk but failed to be parsed",
-		},
-		[]string{"spec_path"},
-	)
-	// SpecExpires contains the time of the next certificate
-	// expiry.
-	SpecExpires = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: metricsNamespace,
-			Subsystem: "spec",
-			Name:      "expire_timestamp",
-			Help:      "The unix time for when the given spec and PKI type expires",
-		},
-		[]string{"spec_path", "type"},
-	)
-
-	// SpecExpiresBeforeThreshold exports how much lead time we give for trying to renew a cert
-	// before it expires.
-	SpecExpiresBeforeThreshold = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: metricsNamespace,
-			Subsystem: "spec",
-			Name:      "expire_before_duration_seconds",
-			Help:      "When a spec is within this number of seconds of an expiry, renewal begins",
-		},
-		[]string{"spec_path"},
-	)
-
-	// SpecWriteCount contains the number of times the PKI on disk was written
-	SpecWriteCount = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: metricsNamespace,
-			Subsystem: "spec",
-			Name:      "write_count",
-			Help:      "The number of times PKI on disk has been rewritten",
-		},
-		[]string{"spec_path"},
-	)
-
-	// SpecWriteFailureCount contains the number of times the PKI on disk failed to be written
-	SpecWriteFailureCount = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: metricsNamespace,
-			Subsystem: "spec",
-			Name:      "write_failure_count",
-			Help:      "The number of times PKI on disk failed to be rewritten",
-		},
-		[]string{"spec_path"},
-	)
-
-	// SpecRequestFailureCount counts the number of times a spec failed to request a certificate from upstream.
-	SpecRequestFailureCount = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: metricsNamespace,
-			Subsystem: "spec",
-			Name:      "request_failure_count",
-			Help:      "Number of failed requests to CA authority for new PKI material",
-		},
-		[]string{"spec_path"},
-	)
-
-	// SpecInterval is set to the interval at which a cert manager wakes up and does its checks
-	SpecInterval = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: metricsNamespace,
-			Subsystem: "spec",
-			Name:      "interval_seconds",
-			Help:      "the time interval that this spec will sleep for between checks",
-		},
-		[]string{"spec_path"},
-	)
-
-	// ActionAttemptedCount counts actions taken by a spec
-	ActionAttemptedCount = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: metricsNamespace,
-			Name:      "action_attempted_count",
-			Help:      "Number of times a spec has taken action",
-		},
-		[]string{"spec_path", "change_type"},
-	)
-
-	// ActionFailedCount counts failed actions taken by a spec
-	ActionFailedCount = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: metricsNamespace,
-			Name:      "action_failed_count",
-			Help:      "Number of failed action runs for a spec",
-		},
-		[]string{"spec_path", "change_type"},
-	)
 )
 
 func init() {
 	startTime = time.Now()
-
-	prometheus.MustRegister(SpecWatchCount)
-	prometheus.MustRegister(SpecRefreshCount)
-	prometheus.MustRegister(SpecCheckCount)
-	prometheus.MustRegister(SpecLoadCount)
-	prometheus.MustRegister(SpecLoadFailureCount)
-	prometheus.MustRegister(SpecExpires)
-	prometheus.MustRegister(SpecExpiresBeforeThreshold)
-	prometheus.MustRegister(SpecWriteCount)
-	prometheus.MustRegister(SpecWriteFailureCount)
-	prometheus.MustRegister(SpecRequestFailureCount)
-	prometheus.MustRegister(SpecInterval)
-	prometheus.MustRegister(ActionAttemptedCount)
-	prometheus.MustRegister(ActionFailedCount)
 }
 
 var indexPage = `<html>

--- a/mgr/manager.go
+++ b/mgr/manager.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/cloudflare/certmgr/cert"
-	"github.com/cloudflare/certmgr/metrics"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	yaml "gopkg.in/yaml.v2"
@@ -135,12 +134,10 @@ var validExtensions = map[string]bool{
 func (m *Manager) loadSpec(path string) (*cert.Spec, error) {
 	log.Infof("manager: loading spec from %s", path)
 	path = filepath.Clean(path)
-	metrics.SpecLoadCount.WithLabelValues(path).Inc()
 	spec, err := cert.Load(path, &(m.MgrSpecOptions.SpecOptions))
 	if err == nil {
 		log.Debugf("manager: successfully loaded spec from %s with begin %v", path, spec.Before)
 	} else {
-		metrics.SpecLoadFailureCount.WithLabelValues(path).Inc()
 		log.Errorf("managed: failed loading spec from %s: %s", path, err)
 	}
 	return spec, err
@@ -207,7 +204,6 @@ func (m *Manager) Load() error {
 		}
 
 		m.Certs = append(m.Certs, spec)
-		metrics.SpecWatchCount.WithLabelValues(spec.Path, spec.ServiceManagerName, spec.Action, spec.CA.Label).Inc()
 		return nil
 	}
 


### PR DESCRIPTION
Export the next wake timestamp, and set the metric name accordingly.

Exporting the interval is quasi useful, but it doesn't tell folks what they
actually want- when will this next try to enforce or do something.

Just export the wake period instead- this aligns more strongly with how things now wake up on their own.

Beyond that, spec_watched_total was dropped (it can be inferred via other metrics), and move the metrics code into spec namespace.