### PR TITLE
Provide a configurable to prevent certmgr from restarting downed services

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ This contains all of the currently available parameters:
 * `metrics_address`: specifies the address for the Prometheus HTTP
   endpoint.
 * `metrics_port`: specifies the port for the Prometheus HTTP endpoint.
+* `take_actions_only_if_running`: boolean, if true, only fire a spec's action if the service is actually running.
+  If this is set to false (the default for historical reasons), this can lead to certmgr starting a downed service
+  when PKI expiry occurs.
 
 
 ## PKI Specs
@@ -184,6 +187,9 @@ A certificate spec has the following fields:
   if a fleet of certmgr are restarted at the same time, their period of wakeup is randomized
   to avoid said fleet waking up and doing interval checks at the same time for a given spec.
   This defaults to the managers default, which defaults to 0 if unspecified.
+* `take_actions_only_if_running`: boolean, if true, only fire a spec's action if the service is actually running.
+  If this is set to false (the default for historical reasons), this can lead to certmgr starting a downed service
+  when PKI expiry occurs.
 
 
 **Note**: `certmgr` will throw a warning if `svcmgr` is `dummy` _AND_ `action` is "nop" or undefined. This is because such a setup will not properly restart or reload a service upon certiifcate renewal, which will likely cause your service to crash. Running `certmgr` with the `--strict` flag will not even load a certificate spec with a `dummy svcmgr` and undefined/nop `action` configuration.

--- a/svcmgr/command.go
+++ b/svcmgr/command.go
@@ -27,21 +27,21 @@ func (cm commandManager) TakeAction(changeType string, specPath string, caPath s
 	return runEnv(env, shellBinary, "-c", cm.command)
 }
 
-func newCommandManager(action string, service string) (Manager, error) {
-	if service != "" {
-		log.Warningf("svcmgr 'command': service '%s' for action '%s' doesn't do anything, ignoring", service, action)
+func newCommandManager(config *Options) (Manager, error) {
+	if config.Service != "" {
+		log.Warningf("svcmgr 'command': service '%s' for action '%s' doesn't do anything, ignoring", config.Service, config.Action)
 	}
 	if canCheckSyntax {
-		log.Debugf("svcmgr 'command': validating the action definition %s", action)
-		err := run(shellBinary, "-n", "-c", action)
+		log.Debugf("svcmgr 'command': validating the action definition %s", config.Action)
+		err := runEnv([]string{}, shellBinary, "-n", "-c", config.Action)
 		if err != nil {
-			return nil, errors.WithMessagef(err, "action %s failed bash -nc parse checks", action)
+			return nil, errors.WithMessagef(err, "action %s failed bash -nc parse checks", config.Action)
 		}
 	} else {
-		log.Warningf("svcmgr 'command': skipping parse check for '%s' since bash couldn't be found", action)
+		log.Warningf("svcmgr 'command': skipping parse check for '%s' since bash couldn't be found", config.Action)
 	}
 	return &commandManager{
-		command: action,
+		command: config.Action,
 	}, nil
 }
 

--- a/svcmgr/svcmgr.go
+++ b/svcmgr/svcmgr.go
@@ -9,12 +9,11 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"syscall"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
-
-type managerCreator func(action string, service string) (Manager, error)
 
 // SupportedBackends map of 'backend' -> creator function.
 var SupportedBackends = map[string]managerCreator{}
@@ -32,10 +31,6 @@ type Manager interface {
 	TakeAction(changeType string, specPath string, caPath string, certPath string, keyPath string) error
 }
 
-func run(prog string, args ...string) error {
-	return runEnv([]string{}, prog, args...)
-}
-
 func runEnv(env []string, prog string, args ...string) error {
 	cmd := exec.Command(prog, args...)
 	cmd.Env = append(os.Environ(), env...)
@@ -43,10 +38,17 @@ func runEnv(env []string, prog string, args ...string) error {
 	return cmd.Run()
 }
 
+// Options is for passing configurables for instantiating a service manager.
+type Options struct {
+	Action            string
+	Service           string
+	CheckTargetStatus bool
+}
+
 // New returns a new service manager.
-func New(name string, action string, service string) (Manager, error) {
+func New(name string, config *Options) (Manager, error) {
 	// if action is nop, then just return dummy.
-	if action == "nop" {
+	if config.Action == "nop" {
 		name = "dummy"
 	}
 	smFunc, ok := SupportedBackends[name]
@@ -54,44 +56,64 @@ func New(name string, action string, service string) (Manager, error) {
 		return nil, fmt.Errorf("svcmgr: unsupported service manager '%s'", name)
 	}
 
-	manager, err := smFunc(action, service)
-	if err != nil && action == "" && service == "" {
+	manager, err := smFunc(config)
+	if err != nil && config.Action == "" && config.Service == "" {
 		return nil, errors.WithMessage(err, "failed to instantiate due to empty action/service; perhaps you meant to use the 'dummy' service manager?")
 	}
 	return manager, err
 }
 
 type simpleManager struct {
-	actionIsLastArgument bool
-	binary               string
-	action               string
-	service              string
+	*Options
+	subCommandIsLastArgument bool
+	serviceBinary            string
+	statusCommand            string
+}
+
+func (sm simpleManager) invoke(env []string, subcommand string) error {
+	if sm.subCommandIsLastArgument {
+		return runEnv(env, sm.serviceBinary, sm.Service, subcommand)
+	}
+	return runEnv(env, sm.serviceBinary, subcommand, sm.Service)
 }
 
 func (sm simpleManager) TakeAction(string, string, string, string, string) error {
-	log.Infof("%ving service %v", sm.action, sm.service)
-	if sm.actionIsLastArgument {
-		return run(sm.binary, sm.service, sm.action)
+	if sm.CheckTargetStatus && sm.statusCommand != "" {
+		err := sm.invoke([]string{}, sm.statusCommand)
+		if err != nil {
+			// yes, this is the way you have to do this.  It sucks.
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				// non zero exit code; log it.
+				log.Infof("status of service %v was non-zero: %v, skipping action", sm.Service, exitErr.Sys().(syscall.WaitStatus).ExitStatus())
+				return nil
+			}
+			return errors.WithMessagef(err, "status check for service %s failed", sm.Service)
+		}
+		// no err means zero exit code.  Proceed.
 	}
-	err := run(sm.binary, sm.action, sm.service)
+	log.Infof("%ving service %v", sm.Action, sm.Service)
+	// service managers don't care what changed, just that we invoke them- thus no env.
+	err := sm.invoke([]string{}, sm.Action)
 	if err != nil {
-		err = fmt.Errorf("failed to %s service %s (err=%s)", sm.action, sm.service, err)
+		err = errors.WithMessagef(err, "failed to %s service %s", sm.Action, sm.Service)
 	}
 	return err
 }
 
-func registerSimpleManager(binary string, actionIsLastArgument bool) managerCreator {
-	return func(action string, service string) (Manager, error) {
-		if !defaultValidActions[action] {
-			return nil, fmt.Errorf("svcmgr: action '%s' is not supported by manager %s", action, binary)
-		} else if service == "" {
-			return nil, fmt.Errorf("svcmgr: manager '%s': action '%s' specified, but service is empty", binary, action)
+type managerCreator func(*Options) (Manager, error)
+
+func registerSimpleManager(binary string, status string, subCommandIsLastArgument bool) managerCreator {
+	return func(config *Options) (Manager, error) {
+		if !defaultValidActions[config.Action] {
+			return nil, fmt.Errorf("svcmgr: action '%s' is not supported by manager %s", config.Action, binary)
+		} else if config.Service == "" {
+			return nil, fmt.Errorf("svcmgr: manager '%s': action '%s' specified, but service is empty", binary, config.Action)
 		}
 		return &simpleManager{
-			binary:               binary,
-			action:               action,
-			service:              service,
-			actionIsLastArgument: actionIsLastArgument,
+			serviceBinary:            binary,
+			statusCommand:            status,
+			subCommandIsLastArgument: subCommandIsLastArgument,
+			Options:                  config,
 		}, nil
 	}
 }
@@ -101,14 +123,14 @@ type dummyManager struct{}
 func (dummyManager) TakeAction(string, string, string, string, string) error {
 	return nil
 }
-func newDummyManager(action string, service string) (Manager, error) {
+func newDummyManager(*Options) (Manager, error) {
 	return &dummyManager{}, nil
 }
 
 func init() {
-	SupportedBackends["circus"] = registerSimpleManager("circus", false)
-	SupportedBackends["openrc"] = registerSimpleManager("rc-service", true)
-	SupportedBackends["systemd"] = registerSimpleManager("systemctl", false)
-	SupportedBackends["sysv"] = registerSimpleManager("service", true)
+	SupportedBackends["circus"] = registerSimpleManager("circus", "status", false)
+	SupportedBackends["openrc"] = registerSimpleManager("rc-service", "status", true)
+	SupportedBackends["systemd"] = registerSimpleManager("systemctl", "is-active", false)
+	SupportedBackends["sysv"] = registerSimpleManager("service", "", true)
 	SupportedBackends["dummy"] = newDummyManager
 }


### PR DESCRIPTION
If PKI expires and an action is configurable, certmgr will fire that action.

If the action is 'restart'- it'll lead to an intentionally downed service
being started, which is less than optimal.

To enable this new behaviour, set `take_actions_only_if_running: true` in
the spec (or manager config).