### PR TITLE
Fix travis builds to work with current project structure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ jobs:
     script:
       - export SOURCE_DATE_EPOCH=$(git show -s --format=%ci ${TRAVIS_TAG:-${TRAVIS_COMMIT}})
       - go get github.com/mitchellh/gox
-      - GOFLAGS=-mod=vendor gox -output="{{.Dir}}-{{.OS}}-{{.Arch}}-${TRAVIS_TAG:-${TRAVIS_COMMIT}}" -os='darwin dragonfly freebsd linux netbsd openbsd solaris' -osarch='!dragonfly/386 !darwin/arm64 !darwin/arm !linux/mips !linux/mipsle' -gcflags="-trimpath=${GOPATH}" ./cmd/certmgr/...
+      - GOFLAGS=-mod=vendor gox -output="{{.Dir}}-{{.OS}}-{{.Arch}}-${TRAVIS_TAG:-${TRAVIS_COMMIT}}" -os='darwin dragonfly freebsd linux netbsd openbsd solaris' -osarch='!dragonfly/386 !darwin/arm64 !darwin/arm !linux/mips !linux/mipsle' -gcflags="-trimpath=${GOPATH}" ./certmgr/...
       - for i in certmgr-*; do tar --mtime="${SOURCE_DATE_EPOCH}" --owner=0 --group=0 --numeric-owner -c $i | gzip -n - > $i.tar.gz; done
       - shasum -a 512 certmgr-*.tar.gz | tee sha512sum.txt
     deploy:


### PR DESCRIPTION
We refactored the project structure in  1ff3b815379bf6ac46649467fa14abc9e9450c26
which broke travis builds. This fixes it.

Demonstrating this change with these env vars set:

export GOFLAGS=-mod=vendor
export TRAVIS_TAG=v3.0.0

Old behavior, no files created:
```
 ❯ touch now; gox -output="{{.Dir}}-{{.OS}}-{{.Arch}}-${TRAVIS_TAG:-${TRAVIS_COMMIT}}" -os='darwin dragonfly freebsd linux netbsd openbsd solaris' -osarch='!dragonfly/386 !darwin/arm64 !darwin/arm !linux/mips !linux/mipsle' -gcflags="-trimpath=${GOPATH}" ./cmd/certmgr/...;find . -newer now
Number of parallel builds: 11

``` 

New behavior:
```
❯ touch now; gox -output="{{.Dir}}-{{.OS}}-{{.Arch}}-${TRAVIS_TAG:-${TRAVIS_COMMIT}}" -os='darwin dragonfly freebsd linux netbsd openbsd solaris' -osarch='!dragonfly/386 !darwin/arm64 !darwin/arm !linux/mips !linux/mipsle' -gcflags="-trimpath=${GOPATH}" ./certmgr/...;find . -newer now
Number of parallel builds: 11

-->      darwin/386: github.com/cloudflare/certmgr/certmgr
-->     freebsd/arm: github.com/cloudflare/certmgr/certmgr
-->   solaris/amd64: github.com/cloudflare/certmgr/certmgr
-->     linux/arm64: github.com/cloudflare/certmgr/certmgr
--> dragonfly/amd64: github.com/cloudflare/certmgr/certmgr
-->     freebsd/386: github.com/cloudflare/certmgr/certmgr
-->    darwin/amd64: github.com/cloudflare/certmgr/certmgr
-->     linux/amd64: github.com/cloudflare/certmgr/certmgr
-->       linux/386: github.com/cloudflare/certmgr/certmgr
-->     linux/ppc64: github.com/cloudflare/certmgr/certmgr
-->  linux/mips64le: github.com/cloudflare/certmgr/certmgr
-->      netbsd/386: github.com/cloudflare/certmgr/certmgr
-->    netbsd/amd64: github.com/cloudflare/certmgr/certmgr
-->      netbsd/arm: github.com/cloudflare/certmgr/certmgr
-->     openbsd/386: github.com/cloudflare/certmgr/certmgr
-->   openbsd/amd64: github.com/cloudflare/certmgr/certmgr
-->       linux/arm: github.com/cloudflare/certmgr/certmgr
-->    linux/mips64: github.com/cloudflare/certmgr/certmgr
-->     linux/s390x: github.com/cloudflare/certmgr/certmgr
-->   freebsd/amd64: github.com/cloudflare/certmgr/certmgr
-->   linux/ppc64le: github.com/cloudflare/certmgr/certmgr
.
./certmgr-darwin-386-v3.0.0
./certmgr-dragonfly-amd64-v3.0.0
./certmgr-linux-amd64-v3.0.0
./certmgr-netbsd-386-v3.0.0
./certmgr-darwin-amd64-v3.0.0
./certmgr-openbsd-386-v3.0.0
./certmgr-linux-s390x-v3.0.0
./certmgr-netbsd-arm-v3.0.0
./certmgr-linux-ppc64le-v3.0.0
./certmgr-netbsd-amd64-v3.0.0
./certmgr-linux-arm-v3.0.0
./certmgr-freebsd-amd64-v3.0.0
./certmgr-solaris-amd64-v3.0.0
./certmgr-freebsd-386-v3.0.0
./certmgr-linux-mips64le-v3.0.0
./certmgr-freebsd-arm-v3.0.0
./certmgr-linux-386-v3.0.0
./certmgr-openbsd-amd64-v3.0.0
./certmgr-linux-arm64-v3.0.0
./certmgr-linux-ppc64-v3.0.0
./certmgr-linux-mips64-v3.0.0
```

