### PR TITLE
Inject currentVersion at buildtime for `certmgr version`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
     script:
       - export SOURCE_DATE_EPOCH=$(git show -s --format=%ci ${TRAVIS_TAG:-${TRAVIS_COMMIT}})
       - go get github.com/mitchellh/gox
-      - GOFLAGS=-mod=vendor gox -output="{{.Dir}}-{{.OS}}-{{.Arch}}-${TRAVIS_TAG:-${TRAVIS_COMMIT}}" -os='darwin dragonfly freebsd linux netbsd openbsd solaris' -osarch='!dragonfly/386 !darwin/arm64 !darwin/arm !linux/mips !linux/mipsle' -gcflags="-trimpath=${GOPATH}" ./certmgr/...
+      - GOFLAGS=-mod=vendor gox -output="{{.Dir}}-{{.OS}}-{{.Arch}}-${TRAVIS_TAG:-${TRAVIS_COMMIT}}" -os='darwin dragonfly freebsd linux netbsd openbsd solaris' -osarch='!dragonfly/386 !darwin/arm64 !darwin/arm !linux/mips !linux/mipsle' -gcflags="-trimpath=${GOPATH}" -ldflags="-X github.com/cloudflare/certmgr/certmgr/cmd.currentVersion=${TRAVIS_TAG:-${TRAVIS_COMMIT}}" ./certmgr/
       - for i in certmgr-*; do tar --mtime="${SOURCE_DATE_EPOCH}" --owner=0 --group=0 --numeric-owner -c $i | gzip -n - > $i.tar.gz; done
       - shasum -a 512 certmgr-*.tar.gz | tee sha512sum.txt
     deploy:

--- a/certmgr/cmd/version.go
+++ b/certmgr/cmd/version.go
@@ -8,7 +8,8 @@ import (
 	"github.com/spf13/viper"
 )
 
-var currentVersion = "2.0.1"
+// We override this at build time with a version number when built in travis
+var currentVersion = "development"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",


### PR DESCRIPTION
Previously we had to change this string whenever releasing a new version.
Now it is injected as part of our build process, keeping it in sync with our releases.

I also changed the path we `go build` from `./certmgr/...` to  `./certmgr/`, to prevent possible future breakage.

```
❯ export TRAVIS_TAG="v123456.8910"
❯ GOFLAGS=-mod=vendor gox -output="{{.Dir}}-{{.OS}}-{{.Arch}}-${TRAVIS_TAG:-${TRAVIS_COMMIT}}" -os='darwin dragonfly freebsd linux netbsd openbsd solaris' -osarch='!dragonfly/386 !darwin/arm64 !darwin/arm !linux/mips !linux/mipsle' -gcflags="-trimpath=${GOPATH}" -ldflags="-X github.com/cloudflare/certmgr/certmgr/cmd.currentVersion=${TRAVIS_TAG:-${TRAVIS_COMMIT}}" ./certmgr/ >/dev/null;./certmgr-darwin-amd64-v123456.8910 version
certmgr version v123456.8910
	built with Go go1.14.2

	Configuration:
	--------------
	certspec directory:
	default remote:
	service manager:
	renew before:		72h0m0s
	check interval:		1h0m0s
```