### PR TITLE
Fix nil pointer dereference when monitoring specs for changes

### DIFF
--- a/certmgr/mgr/file.go
+++ b/certmgr/mgr/file.go
@@ -255,11 +255,13 @@ func ReadSpecFile(path string, defaults *ParsableSpecOptions) (*cert.Spec, error
 
 	s, err := cert.NewSpec(path, &spec.ParsableSpecOptions.SpecOptions, &spec.Authority.Authority, spec.Request, pkiStorage)
 	if err != nil {
-		s.WakeCallbacks = append(s.WakeCallbacks, func() {
-			warnIfHasChangedOnDisk(path, specStat.ModTime())
-		})
+		return nil, err
 	}
-	return s, err
+
+	s.WakeCallbacks = append(s.WakeCallbacks, func() {
+		warnIfHasChangedOnDisk(path, specStat.ModTime())
+	})
+	return s, nil
 }
 
 // warnIfHasChangedOnDisk logs warnings if the spec in memory doesn't reflect what's on disk.


### PR DESCRIPTION
This looks like it was a typo, current behavior is to only add a WakeCallBack if there is an error
and if there is an error, s will be a nil pointer, crashing every time.