### PR TITLE
Fix config parsing

### DIFF
--- a/certmgr/cmd/root.go
+++ b/certmgr/cmd/root.go
@@ -35,7 +35,7 @@ func newManager() (*mgr.Manager, error) {
 				Before:        viper.GetDuration("before"),
 				Interval:      viper.GetDuration("interval"),
 				IntervalSplay: viper.GetDuration("intervalsplay"),
-				InitialSplay:  viper.GetDuration("initial.splay"),
+				InitialSplay:  viper.GetDuration("initialsplay"),
 			},
 		},
 	)
@@ -137,7 +137,7 @@ func init() {
 	RootCmd.PersistentFlags().DurationP("before", "t", cert.DefaultBefore, "how long before certificates expire to start renewing (in duration format)")
 	RootCmd.PersistentFlags().DurationP("interval", "i", cert.DefaultInterval, "how long to sleep before checking for renewal (in duration format)")
 	RootCmd.PersistentFlags().DurationP("intervalsplay", "", 0*time.Second, "a rng value of [0..intervalsplay] to add to each interval to randomize wake time")
-	RootCmd.PersistentFlags().DurationP("initial.splay", "", 0*time.Second, "if specified, this is a rng value of [0..initial.splay] used to randomize the first wake period.  Subsequence wakes use interval configurables.")
+	RootCmd.PersistentFlags().DurationP("initialsplay", "", 0*time.Second, "if specified, this is a rng value of [0..initialsplay] used to randomize the first wake period.  Subsequence wakes use interval configurables.")
 	RootCmd.PersistentFlags().BoolP("log.json", "", false, "if passed, logging will be in json")
 	RootCmd.PersistentFlags().StringP("log.level", "l", "info", "logging level.  Must be one [debug|info|warning|error]")
 	RootCmd.Flags().BoolVarP(&requireSpecs, "requireSpecs", "", false, "fail the daemon startup if no specs were found in the directory to watch")
@@ -147,7 +147,7 @@ func init() {
 	viper.BindPFlag("before", RootCmd.PersistentFlags().Lookup("before"))
 	viper.BindPFlag("interval", RootCmd.PersistentFlags().Lookup("interval"))
 	viper.BindPFlag("intervalsplay", RootCmd.PersistentFlags().Lookup("intervalsplay"))
-	viper.BindPFlag("initial.splay", RootCmd.PersistentFlags().Lookup("initial.splay"))
+	viper.BindPFlag("initialsplay", RootCmd.PersistentFlags().Lookup("initialsplay"))
 	viper.BindPFlag("log.json", RootCmd.PersistentFlags().Lookup("log.json"))
 	viper.BindPFlag("log.level", RootCmd.PersistentFlags().Lookup("log.level"))
 }

--- a/certmgr/cmd/root.go
+++ b/certmgr/cmd/root.go
@@ -23,18 +23,7 @@ import (
 )
 
 var cfgFile string
-var logLevel string
-var jsonLogging bool
 var requireSpecs bool
-
-var manager struct {
-	Dir            string
-	ServiceManager string
-	Before         time.Duration
-	Interval       time.Duration
-	IntervalSplay  time.Duration
-	InitialSplay   time.Duration
-}
 
 func newManager() (*mgr.Manager, error) {
 	return mgr.New(
@@ -45,7 +34,7 @@ func newManager() (*mgr.Manager, error) {
 			SpecOptions: cert.SpecOptions{
 				Before:        viper.GetDuration("before"),
 				Interval:      viper.GetDuration("interval"),
-				IntervalSplay: viper.GetDuration("interval.splay"),
+				IntervalSplay: viper.GetDuration("intervalsplay"),
 				InitialSplay:  viper.GetDuration("initial.splay"),
 			},
 		},
@@ -143,26 +132,29 @@ func init() {
 	cobra.OnInitialize(initConfig)
 
 	RootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "f", "", "config file (default is /etc/certmgr/certmgr.yaml)")
-	RootCmd.PersistentFlags().StringVarP(&manager.Dir, "dir", "d", "", "either the directory containing certificate specs, or the path to the spec file you wish to operate on")
-	RootCmd.PersistentFlags().StringVarP(&manager.ServiceManager, "svcmgr", "m", "", fmt.Sprintf("service manager, must be one of: %s", strings.Join(storage.SupportedServiceBackends, ", ")))
-	RootCmd.PersistentFlags().DurationVarP(&manager.Before, "before", "t", cert.DefaultBefore, "how long before certificates expire to start renewing (in duration format)")
-	RootCmd.PersistentFlags().DurationVarP(&manager.Interval, "interval", "i", cert.DefaultInterval, "how long to sleep before checking for renewal (in duration format)")
-	RootCmd.PersistentFlags().DurationVarP(&manager.IntervalSplay, "interval.splay", "", 0*time.Second, "a rng value of [0..interval.splay] to add to each interval to randomize wake time")
-	RootCmd.PersistentFlags().DurationVarP(&manager.InitialSplay, "initial.splay", "", 0*time.Second, "if specified, this is a rng value of [0..initial.splay] used to randomize the first wake period.  Subsequence wakes use interval configurables.")
-	RootCmd.PersistentFlags().BoolVarP(&jsonLogging, "log.json", "", false, "if passed, logging will be in json")
-	RootCmd.PersistentFlags().StringVarP(&logLevel, "log.level", "l", "info", "logging level.  Must be one [debug|info|warning|error]")
+	RootCmd.PersistentFlags().StringP("dir", "d", "", "either the directory containing certificate specs, or the path to the spec file you wish to operate on")
+	RootCmd.PersistentFlags().StringP("svcmgr", "m", "", fmt.Sprintf("service manager, must be one of: %s", strings.Join(storage.SupportedServiceBackends, ", ")))
+	RootCmd.PersistentFlags().DurationP("before", "t", cert.DefaultBefore, "how long before certificates expire to start renewing (in duration format)")
+	RootCmd.PersistentFlags().DurationP("interval", "i", cert.DefaultInterval, "how long to sleep before checking for renewal (in duration format)")
+	RootCmd.PersistentFlags().DurationP("intervalsplay", "", 0*time.Second, "a rng value of [0..intervalsplay] to add to each interval to randomize wake time")
+	RootCmd.PersistentFlags().DurationP("initial.splay", "", 0*time.Second, "if specified, this is a rng value of [0..initial.splay] used to randomize the first wake period.  Subsequence wakes use interval configurables.")
+	RootCmd.PersistentFlags().BoolP("log.json", "", false, "if passed, logging will be in json")
+	RootCmd.PersistentFlags().StringP("log.level", "l", "info", "logging level.  Must be one [debug|info|warning|error]")
 	RootCmd.Flags().BoolVarP(&requireSpecs, "requireSpecs", "", false, "fail the daemon startup if no specs were found in the directory to watch")
 
 	viper.BindPFlag("dir", RootCmd.PersistentFlags().Lookup("dir"))
 	viper.BindPFlag("svcmgr", RootCmd.PersistentFlags().Lookup("svcmgr"))
 	viper.BindPFlag("before", RootCmd.PersistentFlags().Lookup("before"))
 	viper.BindPFlag("interval", RootCmd.PersistentFlags().Lookup("interval"))
-	viper.BindPFlag("interval.splay", RootCmd.PersistentFlags().Lookup("interval.splay"))
+	viper.BindPFlag("intervalsplay", RootCmd.PersistentFlags().Lookup("intervalsplay"))
 	viper.BindPFlag("initial.splay", RootCmd.PersistentFlags().Lookup("initial.splay"))
+	viper.BindPFlag("log.json", RootCmd.PersistentFlags().Lookup("log.json"))
+	viper.BindPFlag("log.level", RootCmd.PersistentFlags().Lookup("log.level"))
 }
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
+
 	if cfgFile != "" { // enable ability to specify config file via flag
 		viper.SetConfigFile(cfgFile)
 	} else {
@@ -178,7 +170,7 @@ func initConfig() {
 		log.Fatal(err)
 	}
 
-	if err := configureLogging(jsonLogging, logLevel); err != nil {
+	if err := configureLogging(viper.GetBool("log.json"), viper.GetString("log.level")); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/certmgr/cmd/root.go
+++ b/certmgr/cmd/root.go
@@ -34,8 +34,8 @@ func newManager() (*mgr.Manager, error) {
 			SpecOptions: cert.SpecOptions{
 				Before:        viper.GetDuration("before"),
 				Interval:      viper.GetDuration("interval"),
-				IntervalSplay: viper.GetDuration("intervalsplay"),
-				InitialSplay:  viper.GetDuration("initialsplay"),
+				IntervalSplay: viper.GetDuration("interval_splay"),
+				InitialSplay:  viper.GetDuration("initial_splay"),
 			},
 		},
 	)
@@ -136,8 +136,8 @@ func init() {
 	RootCmd.PersistentFlags().StringP("svcmgr", "m", "", fmt.Sprintf("service manager, must be one of: %s", strings.Join(storage.SupportedServiceBackends, ", ")))
 	RootCmd.PersistentFlags().DurationP("before", "t", cert.DefaultBefore, "how long before certificates expire to start renewing (in duration format)")
 	RootCmd.PersistentFlags().DurationP("interval", "i", cert.DefaultInterval, "how long to sleep before checking for renewal (in duration format)")
-	RootCmd.PersistentFlags().DurationP("intervalsplay", "", 0*time.Second, "a rng value of [0..intervalsplay] to add to each interval to randomize wake time")
-	RootCmd.PersistentFlags().DurationP("initialsplay", "", 0*time.Second, "if specified, this is a rng value of [0..initialsplay] used to randomize the first wake period.  Subsequence wakes use interval configurables.")
+	RootCmd.PersistentFlags().DurationP("interval_splay", "", 0*time.Second, "a rng value of [0..intervalsplay] to add to each interval to randomize wake time")
+	RootCmd.PersistentFlags().DurationP("initial_splay", "", 0*time.Second, "if specified, this is a rng value of [0..initial_splay] used to randomize the first wake period.  Subsequence wakes use interval configurables.")
 	RootCmd.PersistentFlags().BoolP("log.json", "", false, "if passed, logging will be in json")
 	RootCmd.PersistentFlags().StringP("log.level", "l", "info", "logging level.  Must be one [debug|info|warning|error]")
 	RootCmd.Flags().BoolVarP(&requireSpecs, "requireSpecs", "", false, "fail the daemon startup if no specs were found in the directory to watch")
@@ -146,8 +146,8 @@ func init() {
 	viper.BindPFlag("svcmgr", RootCmd.PersistentFlags().Lookup("svcmgr"))
 	viper.BindPFlag("before", RootCmd.PersistentFlags().Lookup("before"))
 	viper.BindPFlag("interval", RootCmd.PersistentFlags().Lookup("interval"))
-	viper.BindPFlag("intervalsplay", RootCmd.PersistentFlags().Lookup("intervalsplay"))
-	viper.BindPFlag("initialsplay", RootCmd.PersistentFlags().Lookup("initialsplay"))
+	viper.BindPFlag("interval_splay", RootCmd.PersistentFlags().Lookup("interval_splay"))
+	viper.BindPFlag("initial_splay", RootCmd.PersistentFlags().Lookup("initial_splay"))
 	viper.BindPFlag("log.json", RootCmd.PersistentFlags().Lookup("log.json"))
 	viper.BindPFlag("log.level", RootCmd.PersistentFlags().Lookup("log.level"))
 }

--- a/certmgr/cmd/version.go
+++ b/certmgr/cmd/version.go
@@ -33,7 +33,7 @@ func version(cmd *cobra.Command, args []string) {
 	initial splay:		%s
 `, viper.GetString("dir"), viper.GetString("default_remote"),
 		viper.GetString("svcmgr"), viper.GetString("before"), viper.GetString("interval"),
-		viper.GetString("intervalsplay"), viper.GetString("initialsplay"))
+		viper.GetString("interval_splay"), viper.GetString("initial_splay"))
 }
 
 func init() {

--- a/certmgr/cmd/version.go
+++ b/certmgr/cmd/version.go
@@ -29,8 +29,11 @@ func version(cmd *cobra.Command, args []string) {
 	service manager:	%s
 	renew before:		%s
 	check interval:		%s
+	check splay:		%s
+	initial splay:		%s
 `, viper.GetString("dir"), viper.GetString("default_remote"),
-		viper.GetString("svcmgr"), viper.GetString("before"), viper.GetString("interval"))
+		viper.GetString("svcmgr"), viper.GetString("before"), viper.GetString("interval"),
+		viper.GetString("intervalsplay"), viper.GetString("initial.splay"))
 }
 
 func init() {

--- a/certmgr/cmd/version.go
+++ b/certmgr/cmd/version.go
@@ -33,7 +33,7 @@ func version(cmd *cobra.Command, args []string) {
 	initial splay:		%s
 `, viper.GetString("dir"), viper.GetString("default_remote"),
 		viper.GetString("svcmgr"), viper.GetString("before"), viper.GetString("interval"),
-		viper.GetString("intervalsplay"), viper.GetString("initial.splay"))
+		viper.GetString("intervalsplay"), viper.GetString("initialsplay"))
 }
 
 func init() {


### PR DESCRIPTION
The intermediate object "manager" was removed, as it was unused and made this more confusing.

The intermediate variables for logging have been removed, and replaced with calls to
look up the setting in viper. This fixes configuring logging from config files

The configuration option and cmdline parameter interval.splay has been renamed intervalsplay
This fixes an issue where the 'interval' config would not work if you also specified 'interval: splay:'

"initial.splay" was renamed to "initalsplay" to be consistent with the above change.

The configuration dumping in the 'version' output has also been updated to show the values of the splay settings.