### PR TITLE
Fix versioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
     script:
       - export SOURCE_DATE_EPOCH=$(git show -s --format=%ci ${TRAVIS_TAG:-${TRAVIS_COMMIT}})
       - go get github.com/mitchellh/gox
-      - GOFLAGS=-mod=vendor gox -output="{{.Dir}}-{{.OS}}-{{.Arch}}-${TRAVIS_TAG:-${TRAVIS_COMMIT}}" -os='darwin dragonfly freebsd linux netbsd openbsd solaris' -osarch='!dragonfly/386 !darwin/arm64 !darwin/arm !linux/mips !linux/mipsle' -gcflags="-trimpath=${GOPATH}" -ldflags="-X github.com/cloudflare/certmgr/certmgr/cmd.currentVersion=${TRAVIS_TAG:-${TRAVIS_COMMIT}}" ./certmgr/
+      - GOFLAGS=-mod=vendor gox -output="{{.Dir}}-{{.OS}}-{{.Arch}}-${TRAVIS_TAG:-${TRAVIS_COMMIT}}" -os='darwin dragonfly freebsd linux netbsd openbsd solaris' -osarch='!dragonfly/386 !darwin/arm64 !darwin/arm !linux/mips !linux/mipsle' -gcflags="-trimpath=${GOPATH}" -ldflags="-X github.com/cloudflare/certmgr/certmgr/cmd.currentVersion=$(git describe)" ./certmgr/
       - for i in certmgr-*; do tar --mtime="${SOURCE_DATE_EPOCH}" --owner=0 --group=0 --numeric-owner -c $i | gzip -n - > $i.tar.gz; done
       - shasum -a 512 certmgr-*.tar.gz | tee sha512sum.txt
     deploy:

--- a/certmgr/cmd/root.go
+++ b/certmgr/cmd/root.go
@@ -65,6 +65,8 @@ func createManager() (*mgr.Manager, error) {
 	return mgr, err
 }
 func root(cmd *cobra.Command, args []string) {
+	log.Infof("starting certmgr version %s", currentVersion)
+
 	currentMgr, err := createManager()
 	if err != nil {
 		log.Fatalf("certmgr: %s", err)


### PR DESCRIPTION
This is a small tweak to use `git describe` instead of travis env vars when injecting our version info.

We also now output the version info as a log entry on startup, to better track what is running where.