### PR TITLE
Allow specs to configure what key usage we validate against

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,9 @@ A certificate spec has the following fields:
 * `take_actions_only_if_running`: boolean, if true, only fire a spec's action if the service is actually running.
   If this is set to false (the default for historical reasons), this can lead to certmgr starting a downed service
   when PKI expiry occurs.
+* `key_usages`: optional: An array of strings defining what this key should be used for. Certmgr will consider a cert invalid
+   if it does not contain these key usages. Possible values are from cfssl's [ExtKeyUsage map](https://github.com/cloudflare/cfssl/blob/master/config/config.go#L654)
+  
 
 
 **Note**: `certmgr` will throw a warning if `svcmgr` is `dummy` _AND_ `action` is "nop" or undefined. This is because such a setup will not properly restart or reload a service upon certificate renewal, which will likely cause your service to crash. Running `certmgr` with the `--strict` flag will not even load a certificate spec with a `dummy svcmgr` and undefined/nop `action` configuration.

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ A certificate spec has the following fields:
   If this is set to false (the default for historical reasons), this can lead to certmgr starting a downed service
   when PKI expiry occurs.
 * `key_usages`: optional: An array of strings defining what this key should be used for. Certmgr will consider a cert invalid
-   if it does not contain these key usages. Possible values are from cfssl's [ExtKeyUsage map](https://github.com/cloudflare/cfssl/blob/master/config/config.go#L654)
+   if it does not contain these key usages. Possible values are from cfssl's [ExtKeyUsage map](https://github.com/cloudflare/cfssl/blob/1.3.3/config/config.go#L568)
   
 
 

--- a/cert/spec.go
+++ b/cert/spec.go
@@ -50,9 +50,13 @@ type SpecOptions struct {
 	// This is Primarily useful to force an initial randomization if many nodes with certmgr are restarted all
 	// at the same time.
 	InitialSplay time.Duration
+
+	// KeyUsages specifies what this key will be used for, so that certmgr can verify it is valid for that usage.
+	// It is optional and by default we assume keys will be used for "TLS Web Server Authentication"
+	KeyUsages []x509.ExtKeyUsage
 }
 
-// NewSpecOptions creates a new SpecOptions structu and populates it with defaults.
+// NewSpecOptions creates a new SpecOptions struct and populates it with defaults.
 func NewSpecOptions() *SpecOptions {
 	return &SpecOptions{
 		Before:   DefaultBefore,
@@ -160,7 +164,7 @@ func (spec *Spec) validateStoredPKI(currentCA *x509.Certificate) error {
 	// update internal metrics
 	spec.updateCertExpiry(keyPair.Leaf.NotAfter)
 
-	err = CertificateChainVerify(currentCA, keyPair.Leaf)
+	err = CertificateChainVerify(currentCA, keyPair.Leaf, spec.KeyUsages)
 	if err != nil {
 		return errors.WithMessage(err, "stored cert failed CA check")
 	}

--- a/cert/verification.go
+++ b/cert/verification.go
@@ -41,11 +41,12 @@ func CertificateMatchesHostname(hosts []string, cert *x509.Certificate) bool {
 }
 
 // CertificateChainVerify validates if a given cert is derived from the given CA
-func CertificateChainVerify(ca *x509.Certificate, cert *x509.Certificate) error {
+func CertificateChainVerify(ca *x509.Certificate, cert *x509.Certificate, keyUsages []x509.ExtKeyUsage) error {
 	roots := x509.NewCertPool()
 	roots.AddCert(ca)
 	_, err := cert.Verify(x509.VerifyOptions{
-		Roots: roots,
+		Roots:     roots,
+		KeyUsages: keyUsages,
 	})
 	return err
 }


### PR DESCRIPTION
When a cert is being refreshed we validate it with cert.Verify(), which by default assumes a cert is only valid if it can be used for server authentication.

These changes allow us to specify what our intended usages are and validate against that instead.
