### PR TITLE
Fix parsing yaml, init with genconfig, versioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
     script:
       - export SOURCE_DATE_EPOCH=$(git show -s --format=%ci ${TRAVIS_TAG:-${TRAVIS_COMMIT}})
       - go get github.com/mitchellh/gox
-      - GOFLAGS=-mod=vendor gox -output="{{.Dir}}-{{.OS}}-{{.Arch}}-${TRAVIS_TAG:-${TRAVIS_COMMIT}}" -os='darwin dragonfly freebsd linux netbsd openbsd solaris' -osarch='!dragonfly/386 !darwin/arm64 !darwin/arm !linux/mips !linux/mipsle' -gcflags="-trimpath=${GOPATH}" -ldflags="-X github.com/cloudflare/certmgr/certmgr/cmd.currentVersion=$(git describe)" ./certmgr/
+      - GOFLAGS=-mod=vendor gox -output="{{.Dir}}-{{.OS}}-{{.Arch}}-${TRAVIS_TAG:-${TRAVIS_COMMIT}}" -os='darwin dragonfly freebsd linux netbsd openbsd solaris' -osarch='!dragonfly/386 !darwin/arm64 !darwin/arm !linux/mips !linux/mipsle' -gcflags="-trimpath=${GOPATH}" -ldflags="-X github.com/cloudflare/certmgr/certmgr/cmd.currentVersion=$(git describe --tags)" ./certmgr/
       - for i in certmgr-*; do tar --mtime="${SOURCE_DATE_EPOCH}" --owner=0 --group=0 --numeric-owner -c $i | gzip -n - > $i.tar.gz; done
       - shasum -a 512 certmgr-*.tar.gz | tee sha512sum.txt
     deploy:

--- a/certmgr/cmd/check.go
+++ b/certmgr/cmd/check.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/cloudflare/cfssl/log"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var checkCmd = &cobra.Command{
@@ -17,6 +18,9 @@ checkable during the certificate provisioning process.`,
 }
 
 func check(cmd *cobra.Command, args []string) {
+	if err := viper.ReadInConfig(); err != nil {
+		log.Fatal(err)
+	}
 	mgr, err := newManager()
 	if err != nil {
 		log.Fatalf("Failed: %s", err)

--- a/certmgr/cmd/clean.go
+++ b/certmgr/cmd/clean.go
@@ -5,9 +5,13 @@ import (
 
 	"github.com/cloudflare/cfssl/log"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func clean(cmd *cobra.Command, args []string) {
+	if err := viper.ReadInConfig(); err != nil {
+		log.Fatal(err)
+	}
 	mgr, err := newManager()
 	if err != nil {
 		log.Fatalf("Failed: %s", err)

--- a/certmgr/cmd/ensure.go
+++ b/certmgr/cmd/ensure.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cloudflare/certmgr/cert/storage"
 	"github.com/cloudflare/cfssl/log"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var enableActions = false
@@ -21,6 +22,9 @@ TLS key pairs they identify exist, are valid, and that they are up-to-date.`,
 }
 
 func ensure(cmd *cobra.Command, args []string) {
+	if err := viper.ReadInConfig(); err != nil {
+		log.Fatal(err)
+	}
 	mgr, err := newManager()
 	if err != nil {
 		log.Fatalf("failed creating manager", err)

--- a/certmgr/cmd/root.go
+++ b/certmgr/cmd/root.go
@@ -54,6 +54,9 @@ func createManager() (*mgr.Manager, error) {
 	return mgr, err
 }
 func root(cmd *cobra.Command, args []string) {
+	if err := viper.ReadInConfig(); err != nil {
+		log.Fatal(err)
+	}
 	log.Infof("starting certmgr version %s", currentVersion)
 
 	currentMgr, err := createManager()
@@ -168,8 +171,8 @@ func initConfig() {
 	viper.AutomaticEnv() // read in environment variables that match
 
 	// If a config file is found, read it in.
-	if err := viper.ReadInConfig(); err != nil {
-		log.Fatal(err)
+	if err := viper.ReadInConfig(); err == nil {
+		log.Info("certmgr: loading from config file ", viper.ConfigFileUsed())
 	}
 
 	if err := configureLogging(viper.GetBool("log.json"), viper.GetString("log.level")); err != nil {

--- a/certmgr/mgr/file.go
+++ b/certmgr/mgr/file.go
@@ -35,7 +35,7 @@ var validExtUsage = func() []string {
 // ParsableAuthority is an authority struct that can load the Authkey from content on disk.  This is used internally
 // by Authority for unmarshal- this shouldn't be used for anything but on disk certmgr spec's.
 type ParsableAuthority struct {
-	cert.Authority
+	cert.Authority `yaml:",inline"`
 
 	// Name is an unused field; it was added in v1.4.0 to support loading a full Authority from certmgr config
 	// but was never completed.
@@ -64,7 +64,8 @@ func (pa *ParsableAuthority) UnmarshalJSON(data []byte) error {
 // UnmarshalYAML unmarshal's a YAML representation of Authority object including supporting loading the authkey from
 // a file on disk (thus do not unmarshall untrusted definitions).
 func (pa *ParsableAuthority) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	if err := unmarshal(pa); err != nil {
+	type alias ParsableAuthority
+	if err := unmarshal((*alias)(pa)); err != nil {
 		return err
 	}
 	return pa.loadFromDiskIfNeeded()

--- a/certmgr/mgr/file.go
+++ b/certmgr/mgr/file.go
@@ -140,7 +140,7 @@ func (p *ParsableSpecOptions) FinalizeSpecOptionParsing() {
 // A ParsableSpec is an intermediate struct representing a certmgr spec
 // on disk; this is used for parsing and converted into a Spec
 type ParsableSpec struct {
-	ParsableSpecOptions
+	ParsableSpecOptions `yaml:",inline"`
 
 	// The service is the service that uses this certificate. If
 	// this field is not empty, the action below will be applied


### PR DESCRIPTION
address to #115 [ref](https://github.com/go-yaml/yaml/issues/63)
#114, #107

with this PR you can use yaml for spec files again.
it let us use "certmgr genconfig" again
and inject the latest tag to version while building even it is "lightweight tag" (git tag -lw).