### PR TITLE
fix: Skip host checks for certs with invalid DNS names

### DIFF
--- a/cert/verification.go
+++ b/cert/verification.go
@@ -10,6 +10,10 @@ import (
 
 // CertificateMatchesHostname checks if the Certificates hosts are the same as the given hosts
 func CertificateMatchesHostname(hosts []string, cert *x509.Certificate) bool {
+	// skip checks for kubernetes system certs with invalid DNS names (i.e. CN=system:kube-proxy)
+        if len(hosts) == 1 && len(cert.DNSNames)+len(cert.IPAddresses) == 0 { 
+		return true 
+	}
 	a := make([]string, len(hosts))
 	for idx := range hosts {
 		// normalize the IPs.


### PR DESCRIPTION
Kubernetes system certs have a CN which is not a vaild DNS name (e.g. system:kube-proxy). The hostname check always fails for kubernetes system certs, causing them to be regenerated every 30m, causing trouble.