### PR TITLE
Draft: Fix certmgr 3.0.3 URIs

### DIFF
--- a/cert/verification.go
+++ b/cert/verification.go
@@ -20,10 +20,13 @@ func CertificateMatchesHostname(hosts []string, cert *x509.Certificate) bool {
 			a[idx] = ip.String()
 		}
 	}
-	b := make([]string, len(cert.DNSNames), len(cert.DNSNames)+len(cert.IPAddresses))
+	b := make([]string, len(cert.DNSNames), len(cert.DNSNames)+len(cert.IPAddresses)+len(cert.URIs))
 	copy(b, cert.DNSNames)
 	for idx := range cert.IPAddresses {
 		b = append(b, cert.IPAddresses[idx].String())
+	}
+	for idx := range cert.URIs {
+		b = append(b, cert.URIs[idx].String())
 	}
 
 	if len(a) != len(b) {

--- a/vendor/github.com/cloudflare/cfssl/transport/ca/cfssl_provider.go
+++ b/vendor/github.com/cloudflare/cfssl/transport/ca/cfssl_provider.go
@@ -206,11 +206,15 @@ func (cap *CFSSL) SignCSR(csrPEM []byte) (cert []byte, err error) {
 		return nil, err
 	}
 
-	hosts := make([]string, len(csr.DNSNames), len(csr.DNSNames)+len(csr.IPAddresses))
+	hosts := make([]string, len(csr.DNSNames), len(csr.DNSNames)+len(csr.IPAddresses)+len(csr.URIs))
 	copy(hosts, csr.DNSNames)
 
 	for i := range csr.IPAddresses {
 		hosts = append(hosts, csr.IPAddresses[i].String())
+	}
+
+	for i := range csr.URIs {
+		hosts = append(hosts, csr.URIs[i].String())
 	}
 
 	sreq := &signer.SignRequest{


### PR DESCRIPTION
This PR is really about fixing the validation of URI SANs that was broken since certmgr switched to using the cfssl transport (I think...)

This prevents constant reissuance when the SANs contain URIs.

However, in order to even support URIs properly like the old certmgr 1.x, the cfssl dependency needs to be bumped. To make my life easier, this PR contains a cursed direct patch of the vendored cfssl -- specifically https://github.com/cloudflare/cfssl/pull/1157

This should obviously be removed if ever the ancient cfssl is updated or unvendored.

Until then, the TMP commit makes this PR apply cleanly as a patch on top of v3.0.3